### PR TITLE
Re-export cosmic-text

### DIFF
--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -1,15 +1,11 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
     ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicFontConfig,
-    CosmicFontSystem, CosmicMetrics, CosmicText, CosmicTextPosition,
+    CosmicMetrics, CosmicText, CosmicTextPosition,
 };
 use cosmic_text::AttrsOwned;
 
-fn setup(
-    mut commands: Commands,
-    windows: Query<&Window, With<PrimaryWindow>>,
-    mut font_system: ResMut<CosmicFontSystem>,
-) {
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
     let camera_bundle = Camera2dBundle {
         camera_2d: Camera2d {
@@ -37,13 +33,9 @@ fn setup(
         },
         text_position: CosmicTextPosition::Center,
         cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+        text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
         ..default()
-    }
-    .set_text(
-        CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-        AttrsOwned::new(attrs),
-        &mut font_system.0,
-    );
+    };
 
     let cosmic_edit = commands.spawn(cosmic_edit).id();
 

--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -1,9 +1,8 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition,
+    ActiveEditor, AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle,
+    CosmicFontConfig, CosmicMetrics, CosmicText, CosmicTextPosition,
 };
-use cosmic_text::AttrsOwned;
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();

--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         },
         text_position: CosmicTextPosition::Center,
         cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
+        set_text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
         ..default()
     };
 

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,9 +1,8 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor,
+    ActiveEditor, AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor,
     CosmicFontConfig, CosmicMetrics, CosmicText, CosmicTextPosition,
 };
-use cosmic_text::AttrsOwned;
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,15 +1,11 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
     ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor,
-    CosmicFontConfig, CosmicFontSystem, CosmicMetrics, CosmicText, CosmicTextPosition,
+    CosmicFontConfig, CosmicMetrics, CosmicText, CosmicTextPosition,
 };
 use cosmic_text::AttrsOwned;
 
-fn setup(
-    mut commands: Commands,
-    windows: Query<&Window, With<PrimaryWindow>>,
-    mut font_system: ResMut<CosmicFontSystem>,
-) {
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
     let camera_bundle = Camera2dBundle {
         camera_2d: Camera2d {
@@ -38,13 +34,9 @@ fn setup(
         },
         text_position: CosmicTextPosition::Center,
         cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+        set_text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
         ..default()
-    }
-    .set_text(
-        CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-        AttrsOwned::new(attrs),
-        &mut font_system.0,
-    );
+    };
 
     let cosmic_edit = commands.spawn(cosmic_edit).id();
 

--- a/examples/bevy_api_testing.rs
+++ b/examples/bevy_api_testing.rs
@@ -1,9 +1,8 @@
 use bevy::prelude::*;
 use bevy_cosmic_edit::{
-    change_active_editor_sprite, change_active_editor_ui, ActiveEditor, CosmicAttrs,
-    CosmicEditPlugin, CosmicEditSpriteBundle, CosmicEditUiBundle,
+    bevy_color_to_cosmic, change_active_editor_sprite, change_active_editor_ui, ActiveEditor,
+    Attrs, AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicEditUiBundle,
 };
-use cosmic_text::{Attrs, AttrsOwned};
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
@@ -19,7 +18,7 @@ fn setup(mut commands: Commands) {
             ..default()
         },
         cosmic_attrs: CosmicAttrs(AttrsOwned::new(
-            Attrs::new().color(cosmic_text::Color::rgb(0, 255, 0)),
+            Attrs::new().color(bevy_color_to_cosmic(Color::GREEN)),
         )),
         ..default()
     });

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -1,10 +1,10 @@
 use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    change_active_editor_sprite, change_active_editor_ui, get_x_offset, ActiveEditor, CosmicAttrs,
-    CosmicBackground, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor, CosmicMaxChars,
-    CosmicMaxLines, CosmicMetrics, CosmicText, CosmicTextPosition,
+    bevy_color_to_cosmic, change_active_editor_sprite, change_active_editor_ui, get_x_offset,
+    ActiveEditor, Attrs, AttrsOwned, CosmicAttrs, CosmicBackground, CosmicEditPlugin,
+    CosmicEditUiBundle, CosmicEditor, CosmicMaxChars, CosmicMaxLines, CosmicMetrics, CosmicText,
+    CosmicTextPosition, Edit,
 };
-use cosmic_text::{Attrs, AttrsOwned, Edit};
 
 #[derive(Resource)]
 struct TextChangeTimer(pub Timer);
@@ -12,7 +12,8 @@ struct TextChangeTimer(pub Timer);
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     commands.spawn(Camera2dBundle::default());
 
-    let attrs = AttrsOwned::new(Attrs::new().color(cosmic_text::Color::rgb(69, 69, 69)));
+    let attrs =
+        AttrsOwned::new(Attrs::new().color(bevy_color_to_cosmic(Color::rgb(0.27, 0.27, 0.27))));
     let primary_window = windows.single();
 
     let editor = commands

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -1,0 +1,93 @@
+use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
+use bevy_cosmic_edit::{
+    change_active_editor_sprite, change_active_editor_ui, ActiveEditor, CosmicAttrs,
+    CosmicBackground, CosmicEditPlugin, CosmicEditUiBundle, CosmicMaxChars, CosmicMaxLines,
+    CosmicMetrics, CosmicText, CosmicTextPosition,
+};
+use cosmic_text::{Attrs, AttrsOwned};
+
+#[derive(Resource)]
+struct TextChangeTimer(pub Timer);
+
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let attrs = AttrsOwned::new(Attrs::new().color(cosmic_text::Color::rgb(69, 69, 69)));
+    let primary_window = windows.single();
+
+    let editor = commands
+        .spawn(CosmicEditUiBundle {
+            node: Node::default(),
+            button: Button,
+            visibility: Visibility::Visible,
+            computed_visibility: ComputedVisibility::default(),
+            z_index: ZIndex::default(),
+            image: UiImage::default(),
+            transform: Transform::default(),
+            interaction: Interaction::default(),
+            cosmic_edit_history: bevy_cosmic_edit::CosmicEditHistory::default(),
+            focus_policy: FocusPolicy::default(),
+            text_position: CosmicTextPosition::default(),
+            background_color: BackgroundColor::default(),
+            global_transform: GlobalTransform::default(),
+            background_image: CosmicBackground::default(),
+            border_color: Color::LIME_GREEN.into(),
+            style: Style {
+                // Size and position of text box
+                border: UiRect::all(Val::Px(4.)),
+                width: Val::Percent(20.),
+                height: Val::Px(50.),
+                left: Val::Percent(40.),
+                top: Val::Px(100.),
+                ..default()
+            },
+            cosmic_attrs: CosmicAttrs(attrs.clone()),
+            cosmic_metrics: CosmicMetrics {
+                font_size: 16.,
+                line_height: 16.,
+                scale_factor: primary_window.scale_factor() as f32,
+            },
+            max_chars: CosmicMaxChars(15),
+            max_lines: CosmicMaxLines(1),
+            set_text: CosmicText::OneStyle("BANANA IS THE CODEWORD!".into()),
+        })
+        .id();
+
+    commands.insert_resource(ActiveEditor {
+        entity: Some(editor),
+    });
+
+    commands.insert_resource(TextChangeTimer(Timer::from_seconds(
+        1.,
+        TimerMode::Repeating,
+    )));
+}
+
+// Test for update_buffer_text
+fn text_swapper(
+    mut timer: ResMut<TextChangeTimer>,
+    time: Res<Time>,
+    mut cosmic_q: Query<&mut CosmicText>,
+    mut count: Local<usize>,
+) {
+    timer.0.tick(time.delta());
+    if !timer.0.just_finished() {
+        return;
+    }
+
+    *count += 1;
+    for mut text in cosmic_q.iter_mut() {
+        text.set_if_neq(CosmicText::OneStyle(format!("TIMER {}", *count)));
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(CosmicEditPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, change_active_editor_ui)
+        .add_systems(Update, change_active_editor_sprite)
+        .add_systems(Update, text_swapper)
+        .run();
+}

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -1,10 +1,10 @@
 use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    change_active_editor_sprite, change_active_editor_ui, ActiveEditor, CosmicAttrs,
-    CosmicBackground, CosmicEditPlugin, CosmicEditUiBundle, CosmicMaxChars, CosmicMaxLines,
-    CosmicMetrics, CosmicText, CosmicTextPosition,
+    change_active_editor_sprite, change_active_editor_ui, get_x_offset, ActiveEditor, CosmicAttrs,
+    CosmicBackground, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor, CosmicMaxChars,
+    CosmicMaxLines, CosmicMetrics, CosmicText, CosmicTextPosition,
 };
-use cosmic_text::{Attrs, AttrsOwned};
+use cosmic_text::{Attrs, AttrsOwned, Edit};
 
 #[derive(Resource)]
 struct TextChangeTimer(pub Timer);
@@ -25,7 +25,6 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             image: UiImage::default(),
             transform: Transform::default(),
             interaction: Interaction::default(),
-            cosmic_edit_history: bevy_cosmic_edit::CosmicEditHistory::default(),
             focus_policy: FocusPolicy::default(),
             text_position: CosmicTextPosition::default(),
             background_color: BackgroundColor::default(),
@@ -69,6 +68,7 @@ fn text_swapper(
     time: Res<Time>,
     mut cosmic_q: Query<&mut CosmicText>,
     mut count: Local<usize>,
+    editor_q: Query<&CosmicEditor>,
 ) {
     timer.0.tick(time.delta());
     if !timer.0.just_finished() {
@@ -79,6 +79,9 @@ fn text_swapper(
     for mut text in cosmic_q.iter_mut() {
         text.set_if_neq(CosmicText::OneStyle(format!("TIMER {}", *count)));
     }
+
+    let editor = editor_q.single();
+    println!("X OFFSET: {}", get_x_offset(editor.0.buffer()));
 }
 
 fn main() {

--- a/examples/font_per_widget.rs
+++ b/examples/font_per_widget.rs
@@ -1,13 +1,11 @@
 #![allow(clippy::type_complexity)]
 
 use bevy::{prelude::*, window::PrimaryWindow};
-use bevy_cosmic_edit::change_active_editor_sprite;
-use bevy_cosmic_edit::change_active_editor_ui;
 use bevy_cosmic_edit::{
-    ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition,
+    bevy_color_to_cosmic, change_active_editor_sprite, change_active_editor_ui, ActiveEditor,
+    Attrs, AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicFontConfig,
+    CosmicMetrics, CosmicText, CosmicTextPosition, Family, FontStyle, FontWeight,
 };
-use cosmic_text::{Attrs, AttrsOwned, Family};
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     commands.spawn(Camera2dBundle::default());
@@ -32,24 +30,24 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         vec![
             (
                 String::from("B"),
-                AttrsOwned::new(attrs.weight(cosmic_text::Weight::BOLD)),
+                AttrsOwned::new(attrs.weight(FontWeight::BOLD)),
             ),
             (String::from("old "), AttrsOwned::new(attrs)),
             (
                 String::from("I"),
-                AttrsOwned::new(attrs.style(cosmic_text::Style::Italic)),
+                AttrsOwned::new(attrs.style(FontStyle::Italic)),
             ),
             (String::from("talic "), AttrsOwned::new(attrs)),
             (String::from("f"), AttrsOwned::new(attrs)),
             (String::from("i "), AttrsOwned::new(attrs)),
             (
                 String::from("f"),
-                AttrsOwned::new(attrs.weight(cosmic_text::Weight::BOLD)),
+                AttrsOwned::new(attrs.weight(FontWeight::BOLD)),
             ),
             (String::from("i "), AttrsOwned::new(attrs)),
             (
                 String::from("f"),
-                AttrsOwned::new(attrs.style(cosmic_text::Style::Italic)),
+                AttrsOwned::new(attrs.style(FontStyle::Italic)),
             ),
             (String::from("i "), AttrsOwned::new(attrs)),
         ],
@@ -57,37 +55,33 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             (String::from("Sans-Serif Normal "), AttrsOwned::new(attrs)),
             (
                 String::from("Sans-Serif Bold "),
-                AttrsOwned::new(attrs.weight(cosmic_text::Weight::BOLD)),
+                AttrsOwned::new(attrs.weight(FontWeight::BOLD)),
             ),
             (
                 String::from("Sans-Serif Italic "),
-                AttrsOwned::new(attrs.style(cosmic_text::Style::Italic)),
+                AttrsOwned::new(attrs.style(FontStyle::Italic)),
             ),
             (
                 String::from("Sans-Serif Bold Italic"),
-                AttrsOwned::new(
-                    attrs
-                        .weight(cosmic_text::Weight::BOLD)
-                        .style(cosmic_text::Style::Italic),
-                ),
+                AttrsOwned::new(attrs.weight(FontWeight::BOLD).style(FontStyle::Italic)),
             ),
         ],
         vec![
             (String::from("Serif Normal "), AttrsOwned::new(serif_attrs)),
             (
                 String::from("Serif Bold "),
-                AttrsOwned::new(serif_attrs.weight(cosmic_text::Weight::BOLD)),
+                AttrsOwned::new(serif_attrs.weight(FontWeight::BOLD)),
             ),
             (
                 String::from("Serif Italic "),
-                AttrsOwned::new(serif_attrs.style(cosmic_text::Style::Italic)),
+                AttrsOwned::new(serif_attrs.style(FontStyle::Italic)),
             ),
             (
                 String::from("Serif Bold Italic"),
                 AttrsOwned::new(
                     serif_attrs
-                        .weight(cosmic_text::Weight::BOLD)
-                        .style(cosmic_text::Style::Italic),
+                        .weight(FontWeight::BOLD)
+                        .style(FontStyle::Italic),
                 ),
             ),
         ],
@@ -95,129 +89,125 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             (String::from("Mono Normal "), AttrsOwned::new(mono_attrs)),
             (
                 String::from("Mono Bold "),
-                AttrsOwned::new(mono_attrs.weight(cosmic_text::Weight::BOLD)),
+                AttrsOwned::new(mono_attrs.weight(FontWeight::BOLD)),
             ),
             (
                 String::from("Mono Italic "),
-                AttrsOwned::new(mono_attrs.style(cosmic_text::Style::Italic)),
+                AttrsOwned::new(mono_attrs.style(FontStyle::Italic)),
             ),
             (
                 String::from("Mono Bold Italic"),
-                AttrsOwned::new(
-                    mono_attrs
-                        .weight(cosmic_text::Weight::BOLD)
-                        .style(cosmic_text::Style::Italic),
-                ),
+                AttrsOwned::new(mono_attrs.weight(FontWeight::BOLD).style(FontStyle::Italic)),
             ),
         ],
         vec![
             (String::from("Comic Normal "), AttrsOwned::new(comic_attrs)),
             (
                 String::from("Comic Bold "),
-                AttrsOwned::new(comic_attrs.weight(cosmic_text::Weight::BOLD)),
+                AttrsOwned::new(comic_attrs.weight(FontWeight::BOLD)),
             ),
             (
                 String::from("Comic Italic "),
-                AttrsOwned::new(comic_attrs.style(cosmic_text::Style::Italic)),
+                AttrsOwned::new(comic_attrs.style(FontStyle::Italic)),
             ),
             (
                 String::from("Comic Bold Italic"),
                 AttrsOwned::new(
                     comic_attrs
-                        .weight(cosmic_text::Weight::BOLD)
-                        .style(cosmic_text::Style::Italic),
+                        .weight(FontWeight::BOLD)
+                        .style(FontStyle::Italic),
                 ),
             ),
         ],
         vec![
             (
                 String::from("R"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x00, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::RED))),
             ),
             (
                 String::from("A"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x7F, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::ORANGE))),
             ),
             (
                 String::from("I"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0xFF, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::YELLOW))),
             ),
             (
                 String::from("N"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x00, 0xFF, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::GREEN))),
             ),
             (
                 String::from("B"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x00, 0x00, 0xFF))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::BLUE))),
             ),
             (
                 String::from("O"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x4B, 0x00, 0x82))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::INDIGO))),
             ),
             (
                 String::from("W "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x94, 0x00, 0xD3))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::PURPLE))),
             ),
             (
                 String::from("Red "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x00, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::RED))),
             ),
             (
                 String::from("Orange "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x7F, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::ORANGE))),
             ),
             (
                 String::from("Yellow "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0xFF, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::YELLOW))),
             ),
             (
                 String::from("Green "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x00, 0xFF, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::GREEN))),
             ),
             (
                 String::from("Blue "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x00, 0x00, 0xFF))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::BLUE))),
             ),
             (
                 String::from("Indigo "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x4B, 0x00, 0x82))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::INDIGO))),
             ),
             (
                 String::from("Violet "),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x94, 0x00, 0xD3))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::PURPLE))),
             ),
             (
                 String::from("U"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x94, 0x00, 0xD3))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::PURPLE))),
             ),
             (
                 String::from("N"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x4B, 0x00, 0x82))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::INDIGO))),
             ),
             (
                 String::from("I"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x00, 0x00, 0xFF))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::BLUE))),
             ),
             (
                 String::from("C"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0x00, 0xFF, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::GREEN))),
             ),
             (
                 String::from("O"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0xFF, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::YELLOW))),
             ),
             (
                 String::from("R"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x7F, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::ORANGE))),
             ),
             (
                 String::from("N"),
-                AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x00, 0x00))),
+                AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::RED))),
             ),
         ],
         vec![(
             String::from("生活,삶,जिंदगी 😀 FPS"),
-            AttrsOwned::new(attrs.color(cosmic_text::Color::rgb(0xFF, 0x00, 0x00))),
+            AttrsOwned::new(attrs.color(bevy_color_to_cosmic(Color::RED))),
         )],
     ];
 
@@ -239,9 +229,9 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         ..default()
     };
 
-    let mut attrs_2 = cosmic_text::Attrs::new();
-    attrs_2 = attrs_2.family(cosmic_text::Family::Name("Times New Roman"));
-    attrs_2.color_opt = Some(cosmic_text::Color::rgb(0x94, 0x00, 0xD3));
+    let mut attrs_2 = Attrs::new();
+    attrs_2 = attrs_2.family(Family::Name("Times New Roman"));
+    attrs_2.color_opt = Some(bevy_color_to_cosmic(Color::PURPLE));
 
     let cosmic_edit_2 = CosmicEditUiBundle {
         cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs_2)),

--- a/examples/font_per_widget.rs
+++ b/examples/font_per_widget.rs
@@ -5,15 +5,11 @@ use bevy_cosmic_edit::change_active_editor_sprite;
 use bevy_cosmic_edit::change_active_editor_ui;
 use bevy_cosmic_edit::{
     ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicFontConfig,
-    CosmicFontSystem, CosmicMetrics, CosmicText, CosmicTextPosition,
+    CosmicMetrics, CosmicText, CosmicTextPosition,
 };
 use cosmic_text::{Attrs, AttrsOwned, Family};
 
-fn setup(
-    mut commands: Commands,
-    windows: Query<&Window, With<PrimaryWindow>>,
-    mut font_system: ResMut<CosmicFontSystem>,
-) {
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     commands.spawn(Camera2dBundle::default());
     let root = commands
         .spawn(NodeBundle {
@@ -239,13 +235,9 @@ fn setup(
             ..default()
         },
         background_color: BackgroundColor(Color::WHITE),
+        set_text: CosmicText::MultiStyle(lines),
         ..default()
-    }
-    .set_text(
-        CosmicText::MultiStyle(lines),
-        AttrsOwned::new(attrs),
-        &mut font_system.0,
-    );
+    };
 
     let mut attrs_2 = cosmic_text::Attrs::new();
     attrs_2 = attrs_2.family(cosmic_text::Family::Name("Times New Roman"));
@@ -265,13 +257,9 @@ fn setup(
             height: Val::Percent(100.),
             ..default()
         },
+        set_text: CosmicText::OneStyle("Widget 2.\nClick on me =>".to_string()),
         ..default()
-    }
-    .set_text(
-        CosmicText::OneStyle("Widget 2.\nClick on me =>".to_string()),
-        AttrsOwned::new(attrs_2),
-        &mut font_system.0,
-    );
+    };
 
     let mut id = None;
     // Spawn the CosmicEditUiBundles as children of root

--- a/examples/image_background.rs
+++ b/examples/image_background.rs
@@ -1,9 +1,8 @@
 use bevy::prelude::*;
 use bevy_cosmic_edit::{
-    change_active_editor_sprite, change_active_editor_ui, ActiveEditor, CosmicAttrs,
-    CosmicBackground, CosmicEditPlugin, CosmicEditUiBundle,
+    bevy_color_to_cosmic, change_active_editor_sprite, change_active_editor_ui, ActiveEditor,
+    Attrs, AttrsOwned, CosmicAttrs, CosmicBackground, CosmicEditPlugin, CosmicEditUiBundle,
 };
-use cosmic_text::{Attrs, AttrsOwned};
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
@@ -21,7 +20,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             },
             cosmic_attrs: CosmicAttrs(AttrsOwned::new(
-                Attrs::new().color(cosmic_text::Color::rgb(0, 255, 0)),
+                Attrs::new().color(bevy_color_to_cosmic(Color::GREEN)),
             )),
             background_image: CosmicBackground(Some(bg_image_handle)),
             ..default()

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -37,7 +37,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         transform: Transform::from_translation(Vec3::new(-primary_window.width() / 4., 0., 1.)),
         text_position: CosmicTextPosition::Center,
         background_color: BackgroundColor(Color::ALICE_BLUE),
-        text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
+        set_text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
         ..default()
     };
 
@@ -58,7 +58,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         )),
         text_position: CosmicTextPosition::Center,
         background_color: BackgroundColor(Color::GRAY.with_a(0.5)),
-        text: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
+        set_text: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
         ..default()
     };
 

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -1,11 +1,9 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
-use bevy_cosmic_edit::change_active_editor_sprite;
-use bevy_cosmic_edit::change_active_editor_ui;
 use bevy_cosmic_edit::{
-    ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition,
+    bevy_color_to_cosmic, change_active_editor_sprite, change_active_editor_ui, ActiveEditor,
+    Attrs, AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicFontConfig,
+    CosmicMetrics, CosmicText, CosmicTextPosition, Family,
 };
-use cosmic_text::AttrsOwned;
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
@@ -17,9 +15,9 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     };
     commands.spawn(camera_bundle);
 
-    let mut attrs = cosmic_text::Attrs::new();
-    attrs = attrs.family(cosmic_text::Family::Name("Victor Mono"));
-    attrs = attrs.color(cosmic_text::Color::rgb(0x94, 0x00, 0xD3));
+    let mut attrs = Attrs::new();
+    attrs = attrs.family(Family::Name("Victor Mono"));
+    attrs = attrs.color(bevy_color_to_cosmic(Color::PURPLE));
     let metrics = CosmicMetrics {
         font_size: 14.,
         line_height: 18.,

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -3,15 +3,11 @@ use bevy_cosmic_edit::change_active_editor_sprite;
 use bevy_cosmic_edit::change_active_editor_ui;
 use bevy_cosmic_edit::{
     ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicFontConfig,
-    CosmicFontSystem, CosmicMetrics, CosmicText, CosmicTextPosition,
+    CosmicMetrics, CosmicText, CosmicTextPosition,
 };
 use cosmic_text::AttrsOwned;
 
-fn setup(
-    mut commands: Commands,
-    windows: Query<&Window, With<PrimaryWindow>>,
-    mut font_system: ResMut<CosmicFontSystem>,
-) {
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
     let camera_bundle = Camera2dBundle {
         camera_2d: Camera2d {
@@ -43,13 +39,9 @@ fn setup(
         transform: Transform::from_translation(Vec3::new(-primary_window.width() / 4., 0., 1.)),
         text_position: CosmicTextPosition::Center,
         background_color: BackgroundColor(Color::ALICE_BLUE),
+        text: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
         ..default()
-    }
-    .set_text(
-        CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-        AttrsOwned::new(attrs),
-        &mut font_system.0,
-    );
+    };
 
     let cosmic_edit_2 = CosmicEditSpriteBundle {
         cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
@@ -68,13 +60,9 @@ fn setup(
         )),
         text_position: CosmicTextPosition::Center,
         background_color: BackgroundColor(Color::GRAY.with_a(0.5)),
+        text: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
         ..default()
-    }
-    .set_text(
-        CosmicText::OneStyle("Widget_2. Click on me".to_string()),
-        AttrsOwned::new(attrs),
-        &mut font_system.0,
-    );
+    };
 
     let id = commands.spawn(cosmic_edit_1).id();
 

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -1,9 +1,9 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition, ReadOnly,
+    bevy_color_to_cosmic, ActiveEditor, Attrs, AttrsOwned, CosmicAttrs, CosmicEditPlugin,
+    CosmicEditUiBundle, CosmicFontConfig, CosmicMetrics, CosmicText, CosmicTextPosition, Family,
+    ReadOnly,
 };
-use cosmic_text::AttrsOwned;
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
@@ -20,9 +20,9 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         })
         .id();
 
-    let mut attrs = cosmic_text::Attrs::new();
-    attrs = attrs.family(cosmic_text::Family::Name("Victor Mono"));
-    attrs = attrs.color(cosmic_text::Color::rgb(0x94, 0x00, 0xD3));
+    let mut attrs = Attrs::new();
+    attrs = attrs.family(Family::Name("Victor Mono"));
+    attrs = attrs.color(bevy_color_to_cosmic(Color::PURPLE));
 
     let cosmic_edit = CosmicEditUiBundle {
         style: Style {

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -1,15 +1,11 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
     ActiveEditor, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicFontConfig,
-    CosmicFontSystem, CosmicMetrics, CosmicText, CosmicTextPosition, ReadOnly,
+    CosmicMetrics, CosmicText, CosmicTextPosition, ReadOnly,
 };
 use cosmic_text::AttrsOwned;
 
-fn setup(
-    mut commands: Commands,
-    windows: Query<&Window, With<PrimaryWindow>>,
-    mut font_system: ResMut<CosmicFontSystem>,
-) {
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
     commands.spawn(Camera2dBundle::default());
     let root = commands
@@ -42,13 +38,9 @@ fn setup(
             line_height: 18.,
             scale_factor: primary_window.scale_factor() as f32,
         },
+        set_text: CosmicText::OneStyle("😀😀😀 x => y\nRead only widget".to_string()),
         ..default()
-    }
-    .set_text(
-        CosmicText::OneStyle("😀😀😀 x => y\nRead only widget".to_string()),
-        AttrsOwned::new(attrs),
-        &mut font_system.0,
-    );
+    };
 
     let mut id = None;
     // Spawn the CosmicEditUiBundle as a child of root

--- a/examples/restricted_input.rs
+++ b/examples/restricted_input.rs
@@ -1,15 +1,15 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    change_active_editor_sprite, change_active_editor_ui, ActiveEditor, CosmicAttrs,
-    CosmicEditPlugin, CosmicEditUiBundle, CosmicMaxChars, CosmicMaxLines, CosmicMetrics,
-    CosmicText,
+    bevy_color_to_cosmic, change_active_editor_sprite, change_active_editor_ui, ActiveEditor,
+    Attrs, AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicMaxChars,
+    CosmicMaxLines, CosmicMetrics, CosmicText,
 };
-use cosmic_text::{Attrs, AttrsOwned};
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     commands.spawn(Camera2dBundle::default());
 
-    let attrs = AttrsOwned::new(Attrs::new().color(cosmic_text::Color::rgb(69, 69, 69)));
+    let attrs =
+        AttrsOwned::new(Attrs::new().color(bevy_color_to_cosmic(Color::rgb(0.27, 0.27, 0.27))));
     let primary_window = windows.single();
 
     let editor = commands

--- a/examples/restricted_input.rs
+++ b/examples/restricted_input.rs
@@ -1,53 +1,43 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
     change_active_editor_sprite, change_active_editor_ui, ActiveEditor, CosmicAttrs,
-    CosmicEditPlugin, CosmicEditUiBundle, CosmicFontSystem, CosmicMaxChars, CosmicMaxLines,
-    CosmicMetrics, CosmicText,
+    CosmicEditPlugin, CosmicEditUiBundle, CosmicMaxChars, CosmicMaxLines, CosmicMetrics,
+    CosmicText,
 };
 use cosmic_text::{Attrs, AttrsOwned};
 
-fn setup(
-    mut commands: Commands,
-    mut font_system: ResMut<CosmicFontSystem>,
-    windows: Query<&Window, With<PrimaryWindow>>,
-) {
+fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     commands.spawn(Camera2dBundle::default());
 
     let attrs = AttrsOwned::new(Attrs::new().color(cosmic_text::Color::rgb(69, 69, 69)));
     let primary_window = windows.single();
 
     let editor = commands
-        .spawn(
-            CosmicEditUiBundle {
-                border_color: Color::LIME_GREEN.into(),
-                style: Style {
-                    // Size and position of text box
-                    border: UiRect::all(Val::Px(4.)),
-                    width: Val::Percent(20.),
-                    height: Val::Px(50.),
-                    left: Val::Percent(40.),
-                    top: Val::Px(100.),
-                    ..default()
-                },
-                cosmic_attrs: CosmicAttrs(attrs.clone()),
-                cosmic_metrics: CosmicMetrics {
-                    font_size: 16.,
-                    line_height: 16.,
-                    scale_factor: primary_window.scale_factor() as f32,
-                },
-                max_chars: CosmicMaxChars(15),
-                max_lines: CosmicMaxLines(1),
+        .spawn(CosmicEditUiBundle {
+            border_color: Color::LIME_GREEN.into(),
+            style: Style {
+                // Size and position of text box
+                border: UiRect::all(Val::Px(4.)),
+                width: Val::Percent(20.),
+                height: Val::Px(50.),
+                left: Val::Percent(40.),
+                top: Val::Px(100.),
                 ..default()
-            }
-            .set_text(
-                CosmicText::OneStyle(
-                    "1 line 15 chars! But this\n is longer\n than is\n allowed by\n the limits.\n"
-                        .into(),
-                ),
-                attrs,
-                &mut font_system.0,
+            },
+            cosmic_attrs: CosmicAttrs(attrs.clone()),
+            cosmic_metrics: CosmicMetrics {
+                font_size: 16.,
+                line_height: 16.,
+                scale_factor: primary_window.scale_factor() as f32,
+            },
+            max_chars: CosmicMaxChars(15),
+            max_lines: CosmicMaxLines(1),
+            set_text: CosmicText::OneStyle(
+                "1 line 15 chars! But this\n is longer\n than is\n allowed by\n the limits.\n"
+                    .into(),
             ),
-        )
+            ..default()
+        })
         .id();
 
     commands.insert_resource(ActiveEditor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,13 +365,13 @@ impl Default for CosmicEditSpriteBundle {
 }
 
 #[derive(Clone)]
-struct EditHistoryItem {
+pub struct EditHistoryItem {
     pub cursor: Cursor,
     pub lines: Vec<Vec<(String, AttrsOwned)>>,
 }
 
 #[derive(Component, Default)]
-struct CosmicEditHistory {
+pub struct CosmicEditHistory {
     pub edits: VecDeque<EditHistoryItem>,
     pub current_edit: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@ use bevy::{
     ui::FocusPolicy,
     window::{PrimaryWindow, WindowScaleFactorChanged},
 };
+pub use cosmic_text::{
+    Action, Attrs, AttrsOwned, Cursor, Edit, Family, Style as FontStyle, Weight as FontWeight,
+};
 use cosmic_text::{
-    Action, Attrs, AttrsList, AttrsOwned, Buffer, BufferLine, Cursor, Edit, Editor, FontSystem,
-    Metrics, Shaping, SwashCache,
+    AttrsList, Buffer, BufferLine, Editor, FontSystem, Metrics, Shaping, SwashCache,
 };
 use image::{imageops::FilterType, GenericImageView};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub struct CosmicEditSpriteBundle {
     pub max_lines: CosmicMaxLines,
     /// How many characters are allowed in buffer, 0 for no limit
     pub max_chars: CosmicMaxChars,
-    pub text: CosmicText,
+    pub set_text: CosmicText,
 }
 
 impl Default for CosmicEditSpriteBundle {
@@ -359,7 +359,7 @@ impl Default for CosmicEditSpriteBundle {
             background_image: Default::default(),
             max_lines: Default::default(),
             max_chars: Default::default(),
-            text: Default::default(),
+            set_text: Default::default(),
         }
     }
 }


### PR DESCRIPTION
allows user to use plugin without directly adding dependencies

breaking changes: 
 - set_text is now a `CosmicText` component rather than a bundle method
 - public API for `CosmicEditUiBundle` and `CosmicEditSpriteBundle` have changed: No more `editor` or `cosmic_edit_history` fields; they're applied to entities with new `CosmicText` components automatically

closes #2 