### PR TITLE
rewrite `draw_pixel` for correct color blending

### DIFF
--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -23,6 +23,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             interaction: Interaction::default(),
             focus_policy: FocusPolicy::default(),
             text_position: CosmicTextPosition::default(),
+            fill_color: FillColor::default(),
             background_color: BackgroundColor::default(),
             global_transform: GlobalTransform::default(),
             background_image: CosmicBackground::default(),

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -32,7 +32,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         },
         transform: Transform::from_translation(Vec3::new(-primary_window.width() / 4., 0., 1.)),
         text_position: CosmicTextPosition::Center,
-        background_color: BackgroundColor(Color::ALICE_BLUE),
+        fill_color: FillColor(Color::ALICE_BLUE),
         text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
         ..default()
     };
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             1.,
         )),
         text_position: CosmicTextPosition::Center,
-        background_color: BackgroundColor(Color::GRAY.with_a(0.5)),
+        fill_color: FillColor(Color::GRAY.with_a(0.5)),
         text_setter: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
         ..default()
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1604,7 +1604,7 @@ fn draw_pixel(
 
     buffer[offset + 2] = (out.b() * 255.0) as u8;
     buffer[offset + 1] = (out.g() * 255.0) as u8;
-    buffer[offset + 0] = (out.r() * 255.0) as u8;
+    buffer[offset] = (out.r() * 255.0) as u8;
     buffer[offset + 3] = (bg.a() * 255.0) as u8;
 }
 


### PR DESCRIPTION
Fixes #49 

Causes overlayed text to appear correctly blended

![DONE](https://github.com/StaffEngineer/bevy_cosmic_edit/assets/43527203/68f1e84f-ec2e-4c2c-bb41-269115ed7efe)

Breaking Changes:
 - CosmicEdit*Bundle::background_color renamed to fill_color, and takes a new `FillColor(pub Color)`
     Needed because the `BackgroundColor` is used by Bevy's internal UI system and causes undesired color output.

Has the side-effect of allowing widget transparency, so examples like `multiple_sprites` look significantly different.