### PR TITLE
fix transparent backgrounds with opaque text

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -336,7 +336,7 @@ fn draw_pixel(
     buffer[offset + 2] = (out.b() * 255.0) as u8;
     buffer[offset + 1] = (out.g() * 255.0) as u8;
     buffer[offset] = (out.r() * 255.0) as u8;
-    buffer[offset + 3] = (bg.a() * 255.0) as u8;
+    buffer[offset + 3] = (out.a() * 255.0) as u8;
 }
 
 pub(crate) fn blink_cursor(


### PR DESCRIPTION
fixes #87 

I had a typo

aliases a little on the edges of glyphs when fully transparent
![aliasing](https://github.com/StaffEngineer/bevy_cosmic_edit/assets/43527203/32f3a246-f8e2-4b7c-9154-c734591a3fa0)
