### PR TITLE
simplify bundles

### DIFF
--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -1,7 +1,7 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditSpriteBundle, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition, Focus,
+    AttrsOwned, CosmicAttrs, CosmicEditBundle, CosmicEditPlugin, CosmicFontConfig, CosmicMetrics,
+    CosmicText, CosmicTextPosition, Focus,
 };
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
@@ -20,21 +20,26 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
 
     let scale_factor = primary_window.scale_factor() as f32;
 
-    let cosmic_edit = CosmicEditSpriteBundle {
-        sprite: Sprite {
-            custom_size: Some(Vec2::new(primary_window.width(), primary_window.height())),
+    let cosmic_edit = (
+        CosmicEditBundle {
+            metrics: CosmicMetrics {
+                font_size: 14.,
+                line_height: 18.,
+                scale_factor,
+            },
+            text_position: CosmicTextPosition::Center,
+            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+            text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
             ..default()
         },
-        cosmic_metrics: CosmicMetrics {
-            font_size: 14.,
-            line_height: 18.,
-            scale_factor,
+        SpriteBundle {
+            sprite: Sprite {
+                custom_size: Some(Vec2::new(primary_window.width(), primary_window.height())),
+                ..default()
+            },
+            ..default()
         },
-        text_position: CosmicTextPosition::Center,
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-        ..default()
-    };
+    );
 
     let cosmic_edit = commands.spawn(cosmic_edit).id();
 

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,7 +1,7 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    AttrsOwned, CosmicAttrs, CosmicEditBundle, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor,
-    CosmicFontConfig, CosmicMetrics, CosmicText, CosmicTextPosition, Focus,
+    AttrsOwned, CosmicAttrs, CosmicEditBundle, CosmicEditPlugin, CosmicEditor, CosmicFontConfig,
+    CosmicMetrics, CosmicText, CosmicTextPosition, Focus,
 };
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
@@ -32,16 +32,15 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
             ..default()
         },
-        CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
-                    ..default()
-                },
-                background_color: Color::WHITE.into(),
+        // Use buttonbundle for layout
+        ButtonBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
                 ..default()
             },
+            // Needs to be set to prevent a bug where nothing is displayed
+            background_color: Color::WHITE.into(),
             ..default()
         },
     );

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,7 +1,7 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
-    AttrsOwned, CosmicAttrs, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition, Focus,
+    AttrsOwned, CosmicAttrs, CosmicEditBundle, CosmicEditPlugin, CosmicEditUiBundle, CosmicEditor,
+    CosmicFontConfig, CosmicMetrics, CosmicText, CosmicTextPosition, Focus,
 };
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
@@ -20,22 +20,31 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
 
     let scale_factor = primary_window.scale_factor() as f32;
 
-    let cosmic_edit = CosmicEditUiBundle {
-        style: Style {
-            width: Val::Percent(100.),
-            height: Val::Percent(100.),
+    let cosmic_edit = (
+        CosmicEditBundle {
+            metrics: CosmicMetrics {
+                font_size: 14.,
+                line_height: 18.,
+                scale_factor,
+            },
+            text_position: CosmicTextPosition::Center,
+            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+            text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
             ..default()
         },
-        cosmic_metrics: CosmicMetrics {
-            font_size: 14.,
-            line_height: 18.,
-            scale_factor,
+        CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                background_color: Color::WHITE.into(),
+                ..default()
+            },
+            ..default()
         },
-        text_position: CosmicTextPosition::Center,
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-        ..default()
-    };
+    );
 
     let cosmic_edit = commands.spawn(cosmic_edit).id();
 

--- a/examples/bevy_api_testing.rs
+++ b/examples/bevy_api_testing.rs
@@ -5,37 +5,53 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 
     // spawn a new CosmicEditBundle
-    commands.spawn(CosmicEditUiBundle {
-        style: Style {
-            // Size and position of text box
-            width: Val::Px(300.),
-            height: Val::Px(50.),
-            left: Val::Px(100.),
-            top: Val::Px(100.),
+    let ui_editor = commands
+        .spawn(CosmicEditBundle {
+            attrs: CosmicAttrs(AttrsOwned::new(
+                Attrs::new().color(bevy_color_to_cosmic(Color::GREEN)),
+            )),
+            max_lines: CosmicMaxLines(1),
             ..default()
-        },
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(
-            Attrs::new().color(bevy_color_to_cosmic(Color::GREEN)),
-        )),
-        max_lines: CosmicMaxLines(1),
-        placeholder_setter: PlaceholderText(CosmicText::OneStyle("Place held :)".into())),
-        ..default()
-    });
+        })
+        .insert(CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                style: Style {
+                    // Size and position of text box
+                    width: Val::Px(300.),
+                    height: Val::Px(50.),
+                    left: Val::Px(100.),
+                    top: Val::Px(100.),
+                    ..default()
+                },
+                // needs to be set to prevent a bug where nothing is displayed
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            },
+            ..default()
+        })
+        .insert(CosmicEditPlaceholderBundle {
+            text_setter: PlaceholderText(CosmicText::OneStyle("Placeholder".into())),
+            attrs: PlaceholderAttrs(AttrsOwned::new(
+                Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
+            )),
+        })
+        .id();
 
-    let sprite_editor = commands
-        .spawn(CosmicEditSpriteBundle {
+    commands.spawn((
+        CosmicEditBundle { ..default() },
+        SpriteBundle {
+            // Sets size of text box
             sprite: Sprite {
-                // Sets size of text box
                 custom_size: Some(Vec2::new(300., 100.)),
                 ..default()
             },
             // Position of text box
-            transform: Transform::from_xyz(100., 200., 0.),
+            transform: Transform::from_xyz(0., 100., 0.),
             ..default()
-        })
-        .id();
+        },
+    ));
 
-    commands.insert_resource(Focus(Some(sprite_editor)));
+    commands.insert_resource(Focus(Some(ui_editor)));
 }
 
 fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {

--- a/examples/bevy_api_testing.rs
+++ b/examples/bevy_api_testing.rs
@@ -13,20 +13,17 @@ fn setup(mut commands: Commands) {
             max_lines: CosmicMaxLines(1),
             ..default()
         })
-        .insert(CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                style: Style {
-                    // Size and position of text box
-                    width: Val::Px(300.),
-                    height: Val::Px(50.),
-                    left: Val::Px(100.),
-                    top: Val::Px(100.),
-                    ..default()
-                },
+        .insert(ButtonBundle {
+            style: Style {
+                // Size and position of text box
+                width: Val::Px(300.),
+                height: Val::Px(50.),
+                left: Val::Px(100.),
+                top: Val::Px(100.),
                 // needs to be set to prevent a bug where nothing is displayed
-                background_color: BackgroundColor(Color::WHITE),
                 ..default()
             },
+            background_color: BackgroundColor(Color::WHITE),
             ..default()
         })
         .insert(CosmicEditPlaceholderBundle {

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -28,21 +28,18 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             mode: CosmicMode::Wrap,
             canvas: Default::default(),
         })
-        .insert(CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                border_color: Color::LIME_GREEN.into(),
-                style: Style {
-                    // Size and position of text box
-                    border: UiRect::all(Val::Px(4.)),
-                    width: Val::Percent(20.),
-                    height: Val::Px(50.),
-                    left: Val::Percent(40.),
-                    top: Val::Px(100.),
-                    ..default()
-                },
-                background_color: Color::WHITE.into(),
+        .insert(ButtonBundle {
+            border_color: Color::LIME_GREEN.into(),
+            style: Style {
+                // Size and position of text box
+                border: UiRect::all(Val::Px(4.)),
+                width: Val::Percent(20.),
+                height: Val::Px(50.),
+                left: Val::Percent(40.),
+                top: Val::Px(100.),
                 ..default()
             },
+            background_color: Color::WHITE.into(),
             ..default()
         })
         .insert(CosmicEditPlaceholderBundle {

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
+use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::*;
 
 #[derive(Resource)]
@@ -12,33 +12,12 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     let primary_window = windows.single();
 
     let editor = commands
-        .spawn(CosmicEditUiBundle {
-            node: Node::default(),
-            button: Button,
-            visibility: Visibility::Visible,
-            computed_visibility: ComputedVisibility::default(),
-            z_index: ZIndex::default(),
-            image: UiImage::default(),
-            transform: Transform::default(),
-            interaction: Interaction::default(),
-            focus_policy: FocusPolicy::default(),
+        .spawn(CosmicEditBundle {
             text_position: CosmicTextPosition::default(),
             fill_color: FillColor::default(),
-            background_color: BackgroundColor::default(),
-            global_transform: GlobalTransform::default(),
             background_image: CosmicBackground::default(),
-            border_color: Color::LIME_GREEN.into(),
-            style: Style {
-                // Size and position of text box
-                border: UiRect::all(Val::Px(4.)),
-                width: Val::Percent(20.),
-                height: Val::Px(50.),
-                left: Val::Percent(40.),
-                top: Val::Px(100.),
-                ..default()
-            },
-            cosmic_attrs: CosmicAttrs(attrs.clone()),
-            cosmic_metrics: CosmicMetrics {
+            attrs: CosmicAttrs(attrs.clone()),
+            metrics: CosmicMetrics {
                 font_size: 16.,
                 line_height: 16.,
                 scale_factor: primary_window.scale_factor() as f32,
@@ -47,8 +26,28 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             max_lines: CosmicMaxLines(1),
             text_setter: CosmicText::OneStyle("BANANA IS THE CODEWORD!".into()),
             mode: CosmicMode::Wrap,
-            placeholder_setter: PlaceholderText(CosmicText::OneStyle("Placeholder".into())),
-            placeholder_attrs: PlaceholderAttrs(AttrsOwned::new(
+            canvas: Default::default(),
+        })
+        .insert(CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                border_color: Color::LIME_GREEN.into(),
+                style: Style {
+                    // Size and position of text box
+                    border: UiRect::all(Val::Px(4.)),
+                    width: Val::Percent(20.),
+                    height: Val::Px(50.),
+                    left: Val::Percent(40.),
+                    top: Val::Px(100.),
+                    ..default()
+                },
+                background_color: Color::WHITE.into(),
+                ..default()
+            },
+            ..default()
+        })
+        .insert(CosmicEditPlaceholderBundle {
+            text_setter: PlaceholderText(CosmicText::OneStyle("Placeholder".into())),
+            attrs: PlaceholderAttrs(AttrsOwned::new(
                 Attrs::new().color(CosmicColor::rgb(88, 88, 88)),
             )),
         })

--- a/examples/font_per_widget.rs
+++ b/examples/font_per_widget.rs
@@ -207,45 +207,61 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         )],
     ];
 
-    let cosmic_edit_1 = CosmicEditUiBundle {
-        text_position: bevy_cosmic_edit::CosmicTextPosition::Center,
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        cosmic_metrics: CosmicMetrics {
-            font_size: 18.,
-            line_height: 22.,
-            scale_factor: primary_window.scale_factor() as f32,
-        },
-        style: Style {
-            width: Val::Percent(50.),
-            height: Val::Percent(100.),
+    let cosmic_edit_1 = (
+        CosmicEditBundle {
+            text_position: bevy_cosmic_edit::CosmicTextPosition::Center,
+            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+            metrics: CosmicMetrics {
+                font_size: 18.,
+                line_height: 22.,
+                scale_factor: primary_window.scale_factor() as f32,
+            },
+            text_setter: CosmicText::MultiStyle(lines),
             ..default()
         },
-        background_color: BackgroundColor(Color::WHITE),
-        text_setter: CosmicText::MultiStyle(lines),
-        ..default()
-    };
+        CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                style: Style {
+                    width: Val::Percent(50.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            },
+            ..default()
+        },
+    );
 
     let mut attrs_2 = Attrs::new();
     attrs_2 = attrs_2.family(Family::Name("Times New Roman"));
     attrs_2.color_opt = Some(bevy_color_to_cosmic(Color::PURPLE));
 
-    let cosmic_edit_2 = CosmicEditUiBundle {
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs_2)),
-        cosmic_metrics: CosmicMetrics {
-            font_size: 28.,
-            line_height: 36.,
-            scale_factor: primary_window.scale_factor() as f32,
-        },
-        text_position: CosmicTextPosition::Center,
-        background_color: BackgroundColor(Color::WHITE.with_a(0.8)),
-        style: Style {
-            width: Val::Percent(50.),
-            height: Val::Percent(100.),
+    let cosmic_edit_2 = (
+        CosmicEditBundle {
+            attrs: CosmicAttrs(AttrsOwned::new(attrs_2)),
+            metrics: CosmicMetrics {
+                font_size: 28.,
+                line_height: 36.,
+                scale_factor: primary_window.scale_factor() as f32,
+            },
+            text_position: CosmicTextPosition::Center,
+            text_setter: CosmicText::OneStyle("Widget 2.\nClick on me =>".to_string()),
             ..default()
         },
-        text_setter: CosmicText::OneStyle("Widget 2.\nClick on me =>".to_string()),
-        ..default()
-    };
+        CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                background_color: BackgroundColor(Color::WHITE.with_a(0.8)),
+                style: Style {
+                    width: Val::Percent(50.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                ..default()
+            },
+            ..default()
+        },
+    );
 
     let mut id = None;
     // Spawn the CosmicEditUiBundles as children of root

--- a/examples/font_per_widget.rs
+++ b/examples/font_per_widget.rs
@@ -219,16 +219,13 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             text_setter: CosmicText::MultiStyle(lines),
             ..default()
         },
-        CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                style: Style {
-                    width: Val::Percent(50.),
-                    height: Val::Percent(100.),
-                    ..default()
-                },
-                background_color: BackgroundColor(Color::WHITE),
+        ButtonBundle {
+            style: Style {
+                width: Val::Percent(50.),
+                height: Val::Percent(100.),
                 ..default()
             },
+            background_color: BackgroundColor(Color::WHITE),
             ..default()
         },
     );
@@ -249,14 +246,11 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             text_setter: CosmicText::OneStyle("Widget 2.\nClick on me =>".to_string()),
             ..default()
         },
-        CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                background_color: BackgroundColor(Color::WHITE.with_a(0.8)),
-                style: Style {
-                    width: Val::Percent(50.),
-                    height: Val::Percent(100.),
-                    ..default()
-                },
+        ButtonBundle {
+            background_color: BackgroundColor(Color::WHITE.with_a(0.8)),
+            style: Style {
+                width: Val::Percent(50.),
+                height: Val::Percent(100.),
                 ..default()
             },
             ..default()

--- a/examples/image_background.rs
+++ b/examples/image_background.rs
@@ -14,19 +14,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             background_image: CosmicBackground(Some(bg_image_handle)),
             ..default()
         })
-        .insert(CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                style: Style {
-                    // Size and position of text box
-                    width: Val::Px(300.),
-                    height: Val::Px(50.),
-                    left: Val::Px(100.),
-                    top: Val::Px(100.),
-                    ..default()
-                },
-                background_color: Color::WHITE.into(),
+        .insert(ButtonBundle {
+            style: Style {
+                // Size and position of text box
+                width: Val::Px(300.),
+                height: Val::Px(50.),
+                left: Val::Px(100.),
+                top: Val::Px(100.),
                 ..default()
             },
+            background_color: Color::WHITE.into(),
             ..default()
         })
         .id();

--- a/examples/image_background.rs
+++ b/examples/image_background.rs
@@ -7,19 +7,26 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let bg_image_handle = asset_server.load("img/bevy_logo_light.png");
 
     let editor = commands
-        .spawn(CosmicEditUiBundle {
-            style: Style {
-                // Size and position of text box
-                width: Val::Px(300.),
-                height: Val::Px(50.),
-                left: Val::Px(100.),
-                top: Val::Px(100.),
-                ..default()
-            },
-            cosmic_attrs: CosmicAttrs(AttrsOwned::new(
+        .spawn(CosmicEditBundle {
+            attrs: CosmicAttrs(AttrsOwned::new(
                 Attrs::new().color(bevy_color_to_cosmic(Color::GREEN)),
             )),
             background_image: CosmicBackground(Some(bg_image_handle)),
+            ..default()
+        })
+        .insert(CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                style: Style {
+                    // Size and position of text box
+                    width: Val::Px(300.),
+                    height: Val::Px(50.),
+                    left: Val::Px(100.),
+                    top: Val::Px(100.),
+                    ..default()
+                },
+                background_color: Color::WHITE.into(),
+                ..default()
+            },
             ..default()
         })
         .id();

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -20,43 +20,53 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         scale_factor: primary_window.scale_factor() as f32,
     };
 
-    let cosmic_edit_1 = CosmicEditSpriteBundle {
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        cosmic_metrics: metrics.clone(),
-        sprite: Sprite {
-            custom_size: Some(Vec2 {
-                x: primary_window.width() / 2.,
-                y: primary_window.height(),
-            }),
+    let cosmic_edit_1 = (
+        CosmicEditBundle {
+            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+            metrics: metrics.clone(),
+            text_position: CosmicTextPosition::Center,
+            fill_color: FillColor(Color::ALICE_BLUE),
+            text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
             ..default()
         },
-        transform: Transform::from_translation(Vec3::new(-primary_window.width() / 4., 0., 1.)),
-        text_position: CosmicTextPosition::Center,
-        fill_color: FillColor(Color::ALICE_BLUE),
-        text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-        ..default()
-    };
+        SpriteBundle {
+            sprite: Sprite {
+                custom_size: Some(Vec2 {
+                    x: primary_window.width() / 2.,
+                    y: primary_window.height(),
+                }),
+                ..default()
+            },
+            transform: Transform::from_translation(Vec3::new(-primary_window.width() / 4., 0., 1.)),
+            ..default()
+        },
+    );
 
-    let cosmic_edit_2 = CosmicEditSpriteBundle {
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        cosmic_metrics: metrics,
-        sprite: Sprite {
-            custom_size: Some(Vec2 {
-                x: primary_window.width() / 2.,
-                y: primary_window.height() / 2.,
-            }),
+    let cosmic_edit_2 = (
+        CosmicEditBundle {
+            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+            metrics,
+            text_position: CosmicTextPosition::Center,
+            fill_color: FillColor(Color::GRAY.with_a(0.5)),
+            text_setter: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
             ..default()
         },
-        transform: Transform::from_translation(Vec3::new(
-            primary_window.width() / 4.,
-            -primary_window.height() / 4.,
-            1.,
-        )),
-        text_position: CosmicTextPosition::Center,
-        fill_color: FillColor(Color::GRAY.with_a(0.5)),
-        text_setter: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
-        ..default()
-    };
+        SpriteBundle {
+            sprite: Sprite {
+                custom_size: Some(Vec2 {
+                    x: primary_window.width() / 2.,
+                    y: primary_window.height() / 2.,
+                }),
+                ..default()
+            },
+            transform: Transform::from_translation(Vec3::new(
+                primary_window.width() / 4.,
+                -primary_window.height() / 4.,
+                1.,
+            )),
+            ..default()
+        },
+    );
 
     let id = commands.spawn(cosmic_edit_1).id();
 

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -20,23 +20,31 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     attrs = attrs.family(Family::Name("Victor Mono"));
     attrs = attrs.color(bevy_color_to_cosmic(Color::PURPLE));
 
-    let cosmic_edit = CosmicEditUiBundle {
-        style: Style {
-            width: Val::Percent(100.),
-            height: Val::Percent(100.),
+    let cosmic_edit = (
+        CosmicEditBundle {
+            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+            text_position: CosmicTextPosition::Center,
+            metrics: CosmicMetrics {
+                font_size: 14.,
+                line_height: 18.,
+                scale_factor: primary_window.scale_factor() as f32,
+            },
+            text_setter: CosmicText::OneStyle("😀😀😀 x => y\nRead only widget".to_string()),
             ..default()
         },
-        cosmic_attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-        text_position: CosmicTextPosition::Center,
-        background_color: BackgroundColor(Color::WHITE),
-        cosmic_metrics: CosmicMetrics {
-            font_size: 14.,
-            line_height: 18.,
-            scale_factor: primary_window.scale_factor() as f32,
+        CosmicEditUiBundle {
+            node_bundle: NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            },
+            ..default()
         },
-        text_setter: CosmicText::OneStyle("😀😀😀 x => y\nRead only widget".to_string()),
-        ..default()
-    };
+    );
 
     let mut id = None;
     // Spawn the CosmicEditUiBundle as a child of root

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -32,16 +32,13 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             text_setter: CosmicText::OneStyle("😀😀😀 x => y\nRead only widget".to_string()),
             ..default()
         },
-        CosmicEditUiBundle {
-            node_bundle: NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
-                    ..default()
-                },
-                background_color: BackgroundColor(Color::WHITE),
+        ButtonBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
                 ..default()
             },
+            background_color: BackgroundColor(Color::WHITE),
             ..default()
         },
     );

--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -10,30 +10,41 @@ fn create_editable_widget(commands: &mut Commands, scale_factor: f32, text: Stri
     let placeholder_attrs =
         AttrsOwned::new(Attrs::new().color(bevy_color_to_cosmic(Color::hex("#e6e6e6").unwrap())));
     commands
-        .spawn(CosmicEditUiBundle {
-            border_color: Color::hex("#ededed").unwrap().into(),
-            style: Style {
-                border: UiRect::all(Val::Px(3.)),
-                width: Val::Percent(20.),
-                height: Val::Px(50.),
-                left: Val::Percent(40.),
-                top: Val::Px(100.),
+        .spawn((
+            CosmicEditBundle {
+                attrs: CosmicAttrs(attrs.clone()),
+                metrics: CosmicMetrics {
+                    font_size: 18.,
+                    line_height: 18. * 1.2,
+                    scale_factor,
+                },
+                max_lines: CosmicMaxLines(1),
+                text_setter: CosmicText::OneStyle(text),
+                text_position: CosmicTextPosition::Left { padding: 20 },
+                mode: CosmicMode::InfiniteLine,
                 ..default()
             },
-            cosmic_attrs: CosmicAttrs(attrs.clone()),
-            cosmic_metrics: CosmicMetrics {
-                font_size: 18.,
-                line_height: 18. * 1.2,
-                scale_factor,
+            CosmicEditUiBundle {
+                node_bundle: NodeBundle {
+                    border_color: Color::hex("#ededed").unwrap().into(),
+                    style: Style {
+                        border: UiRect::all(Val::Px(3.)),
+                        width: Val::Percent(20.),
+                        height: Val::Px(50.),
+                        left: Val::Percent(40.),
+                        top: Val::Px(100.),
+                        ..default()
+                    },
+                    background_color: Color::WHITE.into(),
+                    ..default()
+                },
+                ..default()
             },
-            max_lines: CosmicMaxLines(1),
-            text_setter: CosmicText::OneStyle(text),
-            text_position: CosmicTextPosition::Left { padding: 20 },
-            mode: CosmicMode::InfiniteLine,
-            placeholder_setter: PlaceholderText(CosmicText::OneStyle("Type something...".into())),
-            placeholder_attrs: PlaceholderAttrs(placeholder_attrs.clone()),
-            ..default()
-        })
+            CosmicEditPlaceholderBundle {
+                text_setter: PlaceholderText(CosmicText::OneStyle("Type something...".into())),
+                attrs: PlaceholderAttrs(placeholder_attrs.clone()),
+            },
+        ))
         .id()
 }
 
@@ -42,18 +53,9 @@ fn create_readonly_widget(commands: &mut Commands, scale_factor: f32, text: Stri
         AttrsOwned::new(Attrs::new().color(bevy_color_to_cosmic(Color::hex("4d4d4d").unwrap())));
     commands
         .spawn((
-            CosmicEditUiBundle {
-                border_color: Color::hex("#ededed").unwrap().into(),
-                style: Style {
-                    border: UiRect::all(Val::Px(3.)),
-                    width: Val::Percent(20.),
-                    height: Val::Px(50.),
-                    left: Val::Percent(40.),
-                    top: Val::Px(100.),
-                    ..default()
-                },
-                cosmic_attrs: CosmicAttrs(attrs.clone()),
-                cosmic_metrics: CosmicMetrics {
+            CosmicEditBundle {
+                attrs: CosmicAttrs(attrs.clone()),
+                metrics: CosmicMetrics {
                     font_size: 18.,
                     line_height: 18. * 1.2,
                     scale_factor,
@@ -61,6 +63,22 @@ fn create_readonly_widget(commands: &mut Commands, scale_factor: f32, text: Stri
                 text_setter: CosmicText::OneStyle(text),
                 text_position: CosmicTextPosition::Left { padding: 20 },
                 mode: CosmicMode::AutoHeight,
+                ..default()
+            },
+            CosmicEditUiBundle {
+                node_bundle: NodeBundle {
+                    border_color: Color::hex("#ededed").unwrap().into(),
+                    style: Style {
+                        border: UiRect::all(Val::Px(3.)),
+                        width: Val::Percent(20.),
+                        height: Val::Px(50.),
+                        left: Val::Percent(40.),
+                        top: Val::Px(100.),
+                        ..default()
+                    },
+                    background_color: Color::WHITE.into(),
+                    ..default()
+                },
                 ..default()
             },
             ReadOnly,

--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -24,20 +24,17 @@ fn create_editable_widget(commands: &mut Commands, scale_factor: f32, text: Stri
                 mode: CosmicMode::InfiniteLine,
                 ..default()
             },
-            CosmicEditUiBundle {
-                node_bundle: NodeBundle {
-                    border_color: Color::hex("#ededed").unwrap().into(),
-                    style: Style {
-                        border: UiRect::all(Val::Px(3.)),
-                        width: Val::Percent(20.),
-                        height: Val::Px(50.),
-                        left: Val::Percent(40.),
-                        top: Val::Px(100.),
-                        ..default()
-                    },
-                    background_color: Color::WHITE.into(),
+            ButtonBundle {
+                border_color: Color::hex("#ededed").unwrap().into(),
+                style: Style {
+                    border: UiRect::all(Val::Px(3.)),
+                    width: Val::Percent(20.),
+                    height: Val::Px(50.),
+                    left: Val::Percent(40.),
+                    top: Val::Px(100.),
                     ..default()
                 },
+                background_color: Color::WHITE.into(),
                 ..default()
             },
             CosmicEditPlaceholderBundle {
@@ -65,20 +62,17 @@ fn create_readonly_widget(commands: &mut Commands, scale_factor: f32, text: Stri
                 mode: CosmicMode::AutoHeight,
                 ..default()
             },
-            CosmicEditUiBundle {
-                node_bundle: NodeBundle {
-                    border_color: Color::hex("#ededed").unwrap().into(),
-                    style: Style {
-                        border: UiRect::all(Val::Px(3.)),
-                        width: Val::Percent(20.),
-                        height: Val::Px(50.),
-                        left: Val::Percent(40.),
-                        top: Val::Px(100.),
-                        ..default()
-                    },
-                    background_color: Color::WHITE.into(),
+            ButtonBundle {
+                border_color: Color::hex("#ededed").unwrap().into(),
+                style: Style {
+                    border: UiRect::all(Val::Px(3.)),
+                    width: Val::Percent(20.),
+                    height: Val::Px(50.),
+                    left: Val::Percent(40.),
+                    top: Val::Px(100.),
                     ..default()
                 },
+                background_color: Color::WHITE.into(),
                 ..default()
             },
             ReadOnly,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,26 +233,6 @@ pub struct CosmicEditBundle {
 }
 
 #[derive(Bundle)]
-pub struct CosmicEditUiBundle {
-    pub node_bundle: NodeBundle,
-    pub image: UiImage,
-    pub interaction: Interaction,
-}
-
-impl Default for CosmicEditUiBundle {
-    fn default() -> Self {
-        Self {
-            node_bundle: NodeBundle {
-                background_color: BackgroundColor(Color::WHITE),
-                ..default()
-            },
-            image: Default::default(),
-            interaction: Default::default(),
-        }
-    }
-}
-
-#[derive(Bundle)]
 pub struct CosmicEditPlaceholderBundle {
     /// set this to update placeholder text
     pub text_setter: PlaceholderText,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@ mod render;
 
 use std::{collections::VecDeque, path::PathBuf};
 
-use bevy::{
-    prelude::*, render::texture::DEFAULT_IMAGE_HANDLE, transform::TransformSystem, ui::FocusPolicy,
-};
+use bevy::{prelude::*, render::texture::DEFAULT_IMAGE_HANDLE, transform::TransformSystem};
 pub use cosmic_text::{
     Action, Attrs, AttrsOwned, Color as CosmicColor, Cursor, Edit, Family, Style as FontStyle,
     Weight as FontWeight,
@@ -209,154 +207,56 @@ impl Default for PlaceholderAttrs {
         Self(AttrsOwned::new(Attrs::new()))
     }
 }
+
+#[derive(Component)]
+pub struct CosmicCanvas(pub Handle<Image>);
+
+impl Default for CosmicCanvas {
+    fn default() -> Self {
+        CosmicCanvas(DEFAULT_IMAGE_HANDLE.typed())
+    }
+}
+
+#[derive(Bundle, Default)]
+pub struct CosmicEditBundle {
+    // cosmic bits
+    pub fill_color: FillColor,
+    pub text_position: CosmicTextPosition,
+    pub metrics: CosmicMetrics,
+    pub attrs: CosmicAttrs,
+    pub background_image: CosmicBackground,
+    pub max_lines: CosmicMaxLines,
+    pub max_chars: CosmicMaxChars,
+    pub text_setter: CosmicText,
+    pub mode: CosmicMode,
+    pub canvas: CosmicCanvas,
+}
+
 #[derive(Bundle)]
 pub struct CosmicEditUiBundle {
-    // Bevy UI bits
-    /// Describes the logical size of the node
-    pub node: Node,
-    /// Marker component that signals this node is a button
-    pub button: Button,
-    /// Styles which control the layout (size and position) of the node and it's children
-    /// In some cases these styles also affect how the node drawn/painted.
-    pub style: Style,
-    /// Describes whether and how the button has been interacted with by the input
-    pub interaction: Interaction,
-    /// Whether this node should block interaction with lower nodes
-    pub focus_policy: FocusPolicy,
-    /// UiNode Background Color, works as a tint.
-    pub background_color: BackgroundColor,
-    /// The background color, which serves as a "fill" for this node
-    pub fill_color: FillColor,
-    /// The color of the Node's border
-    pub border_color: BorderColor,
-    /// This is used as the cosmic text canvas
+    pub node_bundle: NodeBundle,
     pub image: UiImage,
-    /// The transform of the node
-    ///
-    /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
-    pub transform: Transform,
-    /// The global transform of the node
-    ///
-    /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
-    pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
-    pub visibility: Visibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub computed_visibility: ComputedVisibility,
-    /// Indicates the depth at which the node should appear in the UI
-    pub z_index: ZIndex,
-    // cosmic bits
-    /// text positioning enum
-    pub text_position: CosmicTextPosition,
-    /// text metrics
-    pub cosmic_metrics: CosmicMetrics,
-    /// text attributes
-    pub cosmic_attrs: CosmicAttrs,
-    /// bg img
-    pub background_image: CosmicBackground,
-    /// How many lines are allowed in buffer, 0 for no limit
-    pub max_lines: CosmicMaxLines,
-    /// How many characters are allowed in buffer, 0 for no limit
-    pub max_chars: CosmicMaxChars,
-    /// Setting this will update the buffer's text
-    pub text_setter: CosmicText,
-    /// Text input mode
-    pub mode: CosmicMode,
-    /// Setting this will update the placeholder text
-    pub placeholder_setter: PlaceholderText,
-    pub placeholder_attrs: PlaceholderAttrs,
+    pub interaction: Interaction,
 }
 
 impl Default for CosmicEditUiBundle {
     fn default() -> Self {
         Self {
-            focus_policy: FocusPolicy::Block,
-            node: Default::default(),
-            button: Default::default(),
-            style: Default::default(),
-            border_color: BorderColor(Color::NONE),
-            interaction: Default::default(),
-            fill_color: Default::default(),
+            node_bundle: NodeBundle {
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            },
             image: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-            z_index: Default::default(),
-            text_position: Default::default(),
-            cosmic_metrics: Default::default(),
-            cosmic_attrs: Default::default(),
-            background_image: Default::default(),
-            max_lines: Default::default(),
-            max_chars: Default::default(),
-            text_setter: Default::default(),
-            mode: Default::default(),
-            background_color: BackgroundColor(Color::WHITE),
-            placeholder_setter: Default::default(),
-            placeholder_attrs: Default::default(),
+            interaction: Default::default(),
         }
     }
 }
 
 #[derive(Bundle)]
-pub struct CosmicEditSpriteBundle {
-    // Bevy Sprite Bits
-    pub sprite: Sprite,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
-    pub texture: Handle<Image>,
-    /// User indication of whether an entity is visible
-    pub visibility: Visibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub computed_visibility: ComputedVisibility,
-    /// Widget background color
-    pub fill_color: FillColor,
-    // cosmic bits
-    /// text positioning enum
-    pub text_position: CosmicTextPosition,
-    /// text metrics
-    pub cosmic_metrics: CosmicMetrics,
-    /// text attributes
-    pub cosmic_attrs: CosmicAttrs,
-    /// bg img
-    pub background_image: CosmicBackground,
-    /// How many lines are allowed in buffer, 0 for no limit
-    pub max_lines: CosmicMaxLines,
-    /// How many characters are allowed in buffer, 0 for no limit
-    pub max_chars: CosmicMaxChars,
-    /// Setting this will update the buffer's text
-    pub text_setter: CosmicText,
-    /// Text input mode
-    pub mode: CosmicMode,
-    /// Setting this will update the placeholder text
-    pub placeholder_setter: PlaceholderText,
-    pub placeholder_attrs: PlaceholderAttrs,
-}
-
-impl Default for CosmicEditSpriteBundle {
-    fn default() -> Self {
-        Self {
-            sprite: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            texture: DEFAULT_IMAGE_HANDLE.typed(),
-            visibility: Visibility::Visible,
-            computed_visibility: Default::default(),
-            fill_color: Default::default(),
-            text_position: Default::default(),
-            cosmic_metrics: Default::default(),
-            cosmic_attrs: Default::default(),
-            background_image: Default::default(),
-            max_lines: Default::default(),
-            max_chars: Default::default(),
-            text_setter: Default::default(),
-            mode: Default::default(),
-            placeholder_setter: Default::default(),
-            placeholder_attrs: Default::default(),
-        }
-    }
+pub struct CosmicEditPlaceholderBundle {
+    /// set this to update placeholder text
+    pub text_setter: PlaceholderText,
+    pub attrs: PlaceholderAttrs,
 }
 
 #[derive(Clone)]
@@ -411,6 +311,8 @@ impl Plugin for CosmicEditPlugin {
                 cosmic_editor_builder,
                 placeholder_builder,
                 on_scale_factor_change,
+                render::cosmic_ui_to_canvas,
+                render::cosmic_sprite_to_canvas,
             ),
         )
         .add_systems(PreUpdate, (update_buffer_text, update_placeholder_text))
@@ -425,6 +327,8 @@ impl Plugin for CosmicEditPlugin {
                 freeze_cursor_blink,
                 hide_inactive_or_readonly_cursor,
                 clear_inactive_selection,
+                render::update_handle_ui,
+                render::update_handle_sprite,
             ),
         )
         .add_systems(
@@ -802,7 +706,7 @@ mod tests {
     use crate::*;
 
     fn test_spawn_cosmic_edit_system(mut commands: Commands) {
-        commands.spawn(CosmicEditUiBundle {
+        commands.spawn(CosmicEditBundle {
             text_setter: CosmicText::OneStyle("Blah".into()),
             ..Default::default()
         });


### PR DESCRIPTION
closes #85 

adds a `CosmicCanvas` component to hold the image cosmic draws to. allows easier interop between UI and Sprite widgets

Each type of widget now uses a single `CosmicEditBundle`, adding widget specific components with `.insert()` or as tuples.