### PR TITLE
rework placeholders to use single editor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,10 +332,12 @@ impl Plugin for CosmicEditPlugin {
         .add_systems(
             PostUpdate,
             (
-                (hide_password_text, show_placeholder),
+                hide_password_text,
+                show_placeholder,
                 cosmic_edit_redraw_buffer.after(TransformSystem::TransformPropagate),
                 apply_deferred, // Prevents one-frame inputs adding placeholder to editor
-                (restore_password_text, restore_placeholder_text),
+                restore_password_text,
+                restore_placeholder_text,
             )
                 .chain(),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,18 +202,20 @@ pub struct PlaceholderText(pub CosmicText);
 #[derive(Component)]
 pub struct PlaceholderAttrs(pub AttrsOwned);
 
+impl Default for PlaceholderAttrs {
+    fn default() -> Self {
+        Self(AttrsOwned::new(
+            Attrs::new().color(CosmicColor::rgb(128, 128, 128)),
+        ))
+    }
+}
+
 #[derive(Component)]
 pub struct PasswordInput(pub char);
 
 impl Default for PasswordInput {
     fn default() -> Self {
         PasswordInput("•".chars().next().unwrap())
-    }
-}
-
-impl Default for PlaceholderAttrs {
-    fn default() -> Self {
-        Self(AttrsOwned::new(Attrs::new()))
     }
 }
 


### PR DESCRIPTION
closes #102 

Greatly simplifies the placeholder systems, ripping most of the code around them out. Less code more better :)

Bit to do before it's ready though.

- [x] Multistyle widget with placeholder support ( doesn't matter, placeholder operates when editor is empty )
- [x] Move placeholder functions out of main render, like password input
- [x] Testing