### PR TITLE
Simplify main render system

### DIFF
--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -20,26 +20,24 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
 
     let scale_factor = primary_window.scale_factor() as f32;
 
-    let cosmic_edit = (
-        CosmicEditBundle {
-            metrics: CosmicMetrics {
-                font_size: 14.,
-                line_height: 18.,
-                scale_factor,
-            },
-            text_position: CosmicTextPosition::Center,
-            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-            text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-            ..default()
+    let cosmic_edit = (CosmicEditBundle {
+        metrics: CosmicMetrics {
+            font_size: 14.,
+            line_height: 18.,
+            scale_factor,
         },
-        SpriteBundle {
+        text_position: CosmicTextPosition::Center,
+        attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+        text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
+        sprite_bundle: SpriteBundle {
             sprite: Sprite {
                 custom_size: Some(Vec2::new(primary_window.width(), primary_window.height())),
                 ..default()
             },
             ..default()
         },
-    );
+        ..default()
+    },);
 
     let cosmic_edit = commands.spawn(cosmic_edit).id();
 

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,7 +1,7 @@
 use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*, window::PrimaryWindow};
 use bevy_cosmic_edit::{
     AttrsOwned, CosmicAttrs, CosmicEditBundle, CosmicEditPlugin, CosmicEditor, CosmicFontConfig,
-    CosmicMetrics, CosmicText, CosmicTextPosition, Focus,
+    CosmicMetrics, CosmicSource, CosmicText, CosmicTextPosition, Focus,
 };
 
 fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
@@ -20,8 +20,8 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
 
     let scale_factor = primary_window.scale_factor() as f32;
 
-    let cosmic_edit = (
-        CosmicEditBundle {
+    let cosmic_edit = commands
+        .spawn(CosmicEditBundle {
             metrics: CosmicMetrics {
                 font_size: 14.,
                 line_height: 18.,
@@ -31,21 +31,28 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             attrs: CosmicAttrs(AttrsOwned::new(attrs)),
             text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
             ..default()
-        },
-        // Use buttonbundle for layout
-        ButtonBundle {
-            style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+        })
+        .id();
+
+    commands
+        .spawn(
+            // Use buttonbundle for layout
+            // Includes Interaction and UiImage which are used by the plugin.
+            ButtonBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                // Needs to be set to prevent a bug where nothing is displayed
+                background_color: Color::WHITE.into(),
                 ..default()
             },
-            // Needs to be set to prevent a bug where nothing is displayed
-            background_color: Color::WHITE.into(),
-            ..default()
-        },
-    );
-
-    let cosmic_edit = commands.spawn(cosmic_edit).id();
+        )
+        // point editor at this entity.
+        // Plugin looks for UiImage and sets it's
+        // texture to the editor's rendered image
+        .insert(CosmicSource(cosmic_edit));
 
     commands.insert_resource(Focus(Some(cosmic_edit)));
 }

--- a/examples/bevy_api_testing.rs
+++ b/examples/bevy_api_testing.rs
@@ -4,26 +4,13 @@ use bevy_cosmic_edit::*;
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 
-    // spawn a new CosmicEditBundle
+    // UI editor
     let ui_editor = commands
         .spawn(CosmicEditBundle {
             attrs: CosmicAttrs(AttrsOwned::new(
                 Attrs::new().color(bevy_color_to_cosmic(Color::GREEN)),
             )),
             max_lines: CosmicMaxLines(1),
-            ..default()
-        })
-        .insert(ButtonBundle {
-            style: Style {
-                // Size and position of text box
-                width: Val::Px(300.),
-                height: Val::Px(50.),
-                left: Val::Px(100.),
-                top: Val::Px(100.),
-                // needs to be set to prevent a bug where nothing is displayed
-                ..default()
-            },
-            background_color: BackgroundColor(Color::WHITE),
             ..default()
         })
         .insert(CosmicEditPlaceholderBundle {
@@ -34,9 +21,25 @@ fn setup(mut commands: Commands) {
         })
         .id();
 
-    commands.spawn((
-        CosmicEditBundle { ..default() },
-        SpriteBundle {
+    commands
+        .spawn(ButtonBundle {
+            style: Style {
+                // Size and position of text box
+                width: Val::Px(300.),
+                height: Val::Px(50.),
+                left: Val::Px(100.),
+                top: Val::Px(100.),
+                ..default()
+            },
+            // needs to be set to prevent a bug where nothing is displayed
+            background_color: BackgroundColor(Color::WHITE),
+            ..default()
+        })
+        .insert(CosmicSource(ui_editor));
+
+    // Sprite editor
+    commands.spawn((CosmicEditBundle {
+        sprite_bundle: SpriteBundle {
             // Sets size of text box
             sprite: Sprite {
                 custom_size: Some(Vec2::new(300., 100.)),
@@ -46,7 +49,8 @@ fn setup(mut commands: Commands) {
             transform: Transform::from_xyz(0., 100., 0.),
             ..default()
         },
-    ));
+        ..default()
+    },));
 
     commands.insert_resource(Focus(Some(ui_editor)));
 }
@@ -63,16 +67,13 @@ fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {
 fn change_active_editor_ui(
     mut commands: Commands,
     mut interaction_query: Query<
-        (&Interaction, Entity),
-        (
-            Changed<Interaction>,
-            (With<CosmicEditor>, Without<ReadOnly>),
-        ),
+        (&Interaction, &CosmicSource),
+        (Changed<Interaction>, Without<ReadOnly>),
     >,
 ) {
-    for (interaction, entity) in interaction_query.iter_mut() {
+    for (interaction, source) in interaction_query.iter_mut() {
         if let Interaction::Pressed = interaction {
-            commands.insert_resource(Focus(Some(entity)));
+            commands.insert_resource(Focus(Some(source.0)));
         }
     }
 }
@@ -82,7 +83,7 @@ fn change_active_editor_sprite(
     windows: Query<&Window, With<PrimaryWindow>>,
     buttons: Res<Input<MouseButton>>,
     mut cosmic_edit_query: Query<
-        (&mut Sprite, &GlobalTransform, Entity),
+        (&mut Sprite, &GlobalTransform, &Visibility, Entity),
         (With<CosmicEditor>, Without<ReadOnly>),
     >,
     camera_q: Query<(&Camera, &GlobalTransform)>,
@@ -90,8 +91,11 @@ fn change_active_editor_sprite(
     let window = windows.single();
     let (camera, camera_transform) = camera_q.single();
     if buttons.just_pressed(MouseButton::Left) {
-        for (sprite, node_transform, entity) in &mut cosmic_edit_query.iter_mut() {
-            let size = sprite.custom_size.unwrap_or(Vec2::new(1., 1.));
+        for (sprite, node_transform, visibility, entity) in &mut cosmic_edit_query.iter_mut() {
+            if visibility == Visibility::Hidden {
+                continue;
+            }
+            let size = sprite.custom_size.unwrap_or(Vec2::ONE);
             let x_min = node_transform.affine().translation.x - size.x / 2.;
             let y_min = node_transform.affine().translation.y - size.y / 2.;
             let x_max = node_transform.affine().translation.x + size.x / 2.;

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -26,9 +26,33 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             max_lines: CosmicMaxLines(1),
             text_setter: CosmicText::OneStyle("BANANA IS THE CODEWORD!".into()),
             mode: CosmicMode::Wrap,
-            canvas: Default::default(),
+            // CosmicEdit draws to this spritebundle
+            sprite_bundle: SpriteBundle {
+                sprite: Sprite {
+                    // when using another target like a UI element, this is overridden
+                    custom_size: Some(Vec2::ONE * 128.0),
+                    ..default()
+                },
+                // this is the default behaviour for targeting UI elements.
+                // If wanting a sprite, define your own SpriteBundle and
+                // leave the visibility on. See examples/basic_sprite.rs
+                visibility: Visibility::Hidden,
+                ..default()
+            },
+            // Computed fields
+            padding: Default::default(),
+            widget_size: Default::default(),
         })
-        .insert(ButtonBundle {
+        .insert(CosmicEditPlaceholderBundle {
+            text_setter: PlaceholderText(CosmicText::OneStyle("Placeholder".into())),
+            attrs: PlaceholderAttrs(AttrsOwned::new(
+                Attrs::new().color(CosmicColor::rgb(88, 88, 88)),
+            )),
+        })
+        .id();
+
+    commands
+        .spawn(ButtonBundle {
             border_color: Color::LIME_GREEN.into(),
             style: Style {
                 // Size and position of text box
@@ -42,13 +66,7 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             background_color: Color::WHITE.into(),
             ..default()
         })
-        .insert(CosmicEditPlaceholderBundle {
-            text_setter: PlaceholderText(CosmicText::OneStyle("Placeholder".into())),
-            attrs: PlaceholderAttrs(AttrsOwned::new(
-                Attrs::new().color(CosmicColor::rgb(88, 88, 88)),
-            )),
-        })
-        .id();
+        .insert(CosmicSource(editor));
 
     commands.insert_resource(Focus(Some(editor)));
 

--- a/examples/image_background.rs
+++ b/examples/image_background.rs
@@ -14,7 +14,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             background_image: CosmicBackground(Some(bg_image_handle)),
             ..default()
         })
-        .insert(ButtonBundle {
+        .id();
+
+    commands
+        .spawn(ButtonBundle {
             style: Style {
                 // Size and position of text box
                 width: Val::Px(300.),
@@ -26,7 +29,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             background_color: Color::WHITE.into(),
             ..default()
         })
-        .id();
+        .insert(CosmicSource(editor));
+
     commands.insert_resource(Focus(Some(editor)));
 }
 

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -21,92 +21,8 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
 
     commands.spawn(Camera2dBundle::default());
 
-    let mut login_id = None;
-    let mut password_id = None;
-    let mut submit_id = None;
-    let mut output_id = None;
-
-    commands
-        .spawn(NodeBundle {
-            style: Style {
-                flex_direction: FlexDirection::Column,
-                align_items: AlignItems::Center,
-                padding: UiRect::all(Val::Px(15.0)),
-                width: Val::Px(330.0),
-
-                ..default()
-            },
-            ..default()
-        })
-        .with_children(|root| {
-            login_id = Some(
-                root.spawn(ButtonBundle {
-                    style: Style {
-                        // Size and position of text box
-                        width: Val::Px(300.),
-                        height: Val::Px(50.),
-                        margin: UiRect::all(Val::Px(15.0)),
-                        ..default()
-                    },
-                    background_color: BackgroundColor(Color::WHITE),
-                    ..default()
-                })
-                .id(),
-            );
-
-            password_id = Some(
-                root.spawn(ButtonBundle {
-                    style: Style {
-                        // Size and position of text box
-                        width: Val::Px(300.),
-                        height: Val::Px(50.),
-                        margin: UiRect::all(Val::Px(15.0)),
-                        ..default()
-                    },
-                    background_color: BackgroundColor(Color::WHITE),
-                    ..default()
-                })
-                .id(),
-            );
-
-            submit_id = Some(
-                root.spawn(ButtonBundle {
-                    style: Style {
-                        // Size and position of text box
-                        width: Val::Px(150.),
-                        height: Val::Px(50.),
-                        margin: UiRect::all(Val::Px(15.0)),
-                        border: UiRect::all(Val::Px(3.0)),
-                        ..default()
-                    },
-                    background_color: BackgroundColor(Color::WHITE),
-                    border_color: Color::DARK_GREEN.into(),
-
-                    ..default()
-                })
-                .insert(SubmitButton)
-                .id(),
-            );
-
-            output_id = Some(
-                root.spawn(ButtonBundle {
-                    style: Style {
-                        // Size and position of text box
-                        width: Val::Px(300.),
-                        height: Val::Px(100.),
-                        margin: UiRect::all(Val::Px(15.0)),
-                        ..default()
-                    },
-                    background_color: BackgroundColor(Color::WHITE),
-                    ..default()
-                })
-                .id(),
-            );
-        });
-
     let login_editor = commands
         .spawn(CosmicEditBundle {
-            target: CosmicTarget(login_id),
             max_lines: CosmicMaxLines(1),
             metrics: CosmicMetrics {
                 scale_factor: window.scale_factor() as f32,
@@ -131,9 +47,8 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
         .insert(UsernameTag)
         .id();
 
-    commands
+    let password_editor = commands
         .spawn(CosmicEditBundle {
-            target: CosmicTarget(password_id),
             max_lines: CosmicMaxLines(1),
             metrics: CosmicMetrics {
                 scale_factor: window.scale_factor() as f32,
@@ -148,11 +63,11 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
             )),
         })
         .insert(PasswordTag)
-        .insert(PasswordInput::default());
+        .insert(PasswordInput::default())
+        .id();
 
-    commands
+    let submit_editor = commands
         .spawn(CosmicEditBundle {
-            target: CosmicTarget(submit_id),
             max_lines: CosmicMaxLines(1),
             metrics: CosmicMetrics {
                 font_size: 25.0,
@@ -167,11 +82,11 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
             fill_color: FillColor(Color::GREEN),
             ..default()
         })
-        .insert(ReadOnly);
+        .insert(ReadOnly)
+        .id();
 
-    commands
+    let display_editor = commands
         .spawn(CosmicEditBundle {
-            target: CosmicTarget(output_id),
             metrics: CosmicMetrics {
                 scale_factor: window.scale_factor() as f32,
                 ..default()
@@ -184,9 +99,81 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
                 Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
             )),
         })
-        .insert((ReadOnly, DisplayTag));
+        .insert((ReadOnly, DisplayTag))
+        .id();
 
     commands.insert_resource(Focus(Some(login_editor)));
+
+    // Spawn UI
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                padding: UiRect::all(Val::Px(15.0)),
+                width: Val::Px(330.0),
+
+                ..default()
+            },
+            ..default()
+        })
+        .with_children(|root| {
+            root.spawn(ButtonBundle {
+                style: Style {
+                    // Size and position of text box
+                    width: Val::Px(300.),
+                    height: Val::Px(50.),
+                    margin: UiRect::all(Val::Px(15.0)),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            })
+            .insert(CosmicSource(login_editor));
+
+            root.spawn(ButtonBundle {
+                style: Style {
+                    // Size and position of text box
+                    width: Val::Px(300.),
+                    height: Val::Px(50.),
+                    margin: UiRect::all(Val::Px(15.0)),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            })
+            .insert(CosmicSource(password_editor));
+
+            root.spawn(ButtonBundle {
+                style: Style {
+                    // Size and position of text box
+                    width: Val::Px(150.),
+                    height: Val::Px(50.),
+                    margin: UiRect::all(Val::Px(15.0)),
+                    border: UiRect::all(Val::Px(3.0)),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                border_color: Color::DARK_GREEN.into(),
+
+                ..default()
+            })
+            .insert(SubmitButton)
+            .insert(CosmicSource(submit_editor));
+
+            root.spawn(ButtonBundle {
+                style: Style {
+                    // Size and position of text box
+                    width: Val::Px(300.),
+                    height: Val::Px(100.),
+                    margin: UiRect::all(Val::Px(15.0)),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            })
+            .insert(CosmicSource(display_editor));
+        });
 }
 
 fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {
@@ -201,16 +188,13 @@ fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {
 fn change_active_editor_ui(
     mut commands: Commands,
     mut interaction_query: Query<
-        (&Interaction, Entity),
-        (
-            Changed<Interaction>,
-            (With<CosmicEditor>, Without<ReadOnly>),
-        ),
+        (&Interaction, &CosmicSource),
+        (Changed<Interaction>, Without<ReadOnly>),
     >,
 ) {
-    for (interaction, entity) in interaction_query.iter_mut() {
+    for (interaction, source) in interaction_query.iter_mut() {
         if let Interaction::Pressed = interaction {
-            commands.insert_resource(Focus(Some(entity)));
+            commands.insert_resource(Focus(Some(source.0)));
         }
     }
 }

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -21,6 +21,11 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
 
     commands.spawn(Camera2dBundle::default());
 
+    let mut login_id = None;
+    let mut password_id = None;
+    let mut submit_id = None;
+    let mut output_id = None;
+
     commands
         .spawn(NodeBundle {
             style: Style {
@@ -34,119 +39,143 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
             ..default()
         })
         .with_children(|root| {
-            root.spawn(CosmicEditBundle {
-                max_lines: CosmicMaxLines(1),
-                metrics: CosmicMetrics {
-                    scale_factor: window.scale_factor() as f32,
+            login_id = Some(
+                root.spawn(ButtonBundle {
+                    style: Style {
+                        // Size and position of text box
+                        width: Val::Px(300.),
+                        height: Val::Px(50.),
+                        margin: UiRect::all(Val::Px(15.0)),
+                        ..default()
+                    },
+                    background_color: BackgroundColor(Color::WHITE),
                     ..default()
-                },
-                ..default()
-            })
-            .insert(ButtonBundle {
-                style: Style {
-                    // Size and position of text box
-                    width: Val::Px(300.),
-                    height: Val::Px(50.),
-                    margin: UiRect::all(Val::Px(15.0)),
-                    ..default()
-                },
-                background_color: BackgroundColor(Color::WHITE),
-                ..default()
-            })
-            .insert(CosmicEditPlaceholderBundle {
-                text_setter: PlaceholderText(CosmicText::OneStyle("Username".into())),
-                attrs: PlaceholderAttrs(AttrsOwned::new(
-                    Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
-                )),
-            })
-            .insert(UsernameTag);
+                })
+                .id(),
+            );
 
-            root.spawn(CosmicEditBundle {
-                max_lines: CosmicMaxLines(1),
-                metrics: CosmicMetrics {
-                    scale_factor: window.scale_factor() as f32,
+            password_id = Some(
+                root.spawn(ButtonBundle {
+                    style: Style {
+                        // Size and position of text box
+                        width: Val::Px(300.),
+                        height: Val::Px(50.),
+                        margin: UiRect::all(Val::Px(15.0)),
+                        ..default()
+                    },
+                    background_color: BackgroundColor(Color::WHITE),
                     ..default()
-                },
-                ..default()
-            })
-            .insert(ButtonBundle {
-                style: Style {
-                    // Size and position of text box
-                    width: Val::Px(300.),
-                    height: Val::Px(50.),
-                    margin: UiRect::all(Val::Px(15.0)),
-                    ..default()
-                },
-                background_color: BackgroundColor(Color::WHITE),
-                ..default()
-            })
-            .insert(CosmicEditPlaceholderBundle {
-                text_setter: PlaceholderText(CosmicText::OneStyle("Password".into())),
-                attrs: PlaceholderAttrs(AttrsOwned::new(
-                    Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
-                )),
-            })
-            .insert(PasswordTag)
-            .insert(PasswordInput::default());
+                })
+                .id(),
+            );
 
-            root.spawn(CosmicEditBundle {
-                max_lines: CosmicMaxLines(1),
-                metrics: CosmicMetrics {
-                    font_size: 25.0,
-                    line_height: 25.0,
-                    scale_factor: window.scale_factor() as f32,
-                    ..default()
-                },
-                attrs: CosmicAttrs(AttrsOwned::new(
-                    Attrs::new().color(bevy_color_to_cosmic(Color::WHITE)),
-                )),
-                text_setter: CosmicText::OneStyle("Submit".into()),
-                fill_color: FillColor(Color::GREEN),
-                ..default()
-            })
-            .insert(ButtonBundle {
-                style: Style {
-                    // Size and position of text box
-                    width: Val::Px(150.),
-                    height: Val::Px(50.),
-                    margin: UiRect::all(Val::Px(15.0)),
-                    border: UiRect::all(Val::Px(3.0)),
-                    ..default()
-                },
-                background_color: BackgroundColor(Color::WHITE),
-                border_color: Color::DARK_GREEN.into(),
+            submit_id = Some(
+                root.spawn(ButtonBundle {
+                    style: Style {
+                        // Size and position of text box
+                        width: Val::Px(150.),
+                        height: Val::Px(50.),
+                        margin: UiRect::all(Val::Px(15.0)),
+                        border: UiRect::all(Val::Px(3.0)),
+                        ..default()
+                    },
+                    background_color: BackgroundColor(Color::WHITE),
+                    border_color: Color::DARK_GREEN.into(),
 
-                ..default()
-            })
-            .insert(SubmitButton)
-            .insert(ReadOnly);
+                    ..default()
+                })
+                .insert(SubmitButton)
+                .id(),
+            );
 
-            root.spawn(CosmicEditBundle {
-                metrics: CosmicMetrics {
-                    scale_factor: window.scale_factor() as f32,
+            output_id = Some(
+                root.spawn(ButtonBundle {
+                    style: Style {
+                        // Size and position of text box
+                        width: Val::Px(300.),
+                        height: Val::Px(100.),
+                        margin: UiRect::all(Val::Px(15.0)),
+                        ..default()
+                    },
+                    background_color: BackgroundColor(Color::WHITE),
                     ..default()
-                },
-                ..default()
-            })
-            .insert(ButtonBundle {
-                style: Style {
-                    // Size and position of text box
-                    width: Val::Px(300.),
-                    height: Val::Px(100.),
-                    margin: UiRect::all(Val::Px(15.0)),
-                    ..default()
-                },
-                background_color: BackgroundColor(Color::WHITE),
-                ..default()
-            })
-            .insert(CosmicEditPlaceholderBundle {
-                text_setter: PlaceholderText(CosmicText::OneStyle("Output".into())),
-                attrs: PlaceholderAttrs(AttrsOwned::new(
-                    Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
-                )),
-            })
-            .insert((ReadOnly, DisplayTag));
+                })
+                .id(),
+            );
         });
+
+    commands
+        .spawn(CosmicEditBundle {
+            target: CosmicTarget(login_id),
+            max_lines: CosmicMaxLines(1),
+            metrics: CosmicMetrics {
+                scale_factor: window.scale_factor() as f32,
+                ..default()
+            },
+            ..default()
+        })
+        .insert(CosmicEditPlaceholderBundle {
+            text_setter: PlaceholderText(CosmicText::OneStyle("Username".into())),
+            attrs: PlaceholderAttrs(AttrsOwned::new(
+                Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
+            )),
+        })
+        .insert(UsernameTag);
+
+    commands
+        .spawn(CosmicEditBundle {
+            target: CosmicTarget(password_id),
+            max_lines: CosmicMaxLines(1),
+            metrics: CosmicMetrics {
+                scale_factor: window.scale_factor() as f32,
+                ..default()
+            },
+            ..default()
+        })
+        .insert(CosmicEditPlaceholderBundle {
+            text_setter: PlaceholderText(CosmicText::OneStyle("Password".into())),
+            attrs: PlaceholderAttrs(AttrsOwned::new(
+                Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
+            )),
+        })
+        .insert(PasswordTag)
+        .insert(PasswordInput::default());
+
+    commands
+        .spawn(CosmicEditBundle {
+            target: CosmicTarget(submit_id),
+            max_lines: CosmicMaxLines(1),
+            metrics: CosmicMetrics {
+                font_size: 25.0,
+                line_height: 25.0,
+                scale_factor: window.scale_factor() as f32,
+                ..default()
+            },
+            attrs: CosmicAttrs(AttrsOwned::new(
+                Attrs::new().color(bevy_color_to_cosmic(Color::WHITE)),
+            )),
+            text_setter: CosmicText::OneStyle("Submit".into()),
+            fill_color: FillColor(Color::GREEN),
+            ..default()
+        })
+        .insert(ReadOnly);
+
+    commands
+        .spawn(CosmicEditBundle {
+            target: CosmicTarget(output_id),
+            metrics: CosmicMetrics {
+                scale_factor: window.scale_factor() as f32,
+                ..default()
+            },
+            ..default()
+        })
+        .insert(CosmicEditPlaceholderBundle {
+            text_setter: PlaceholderText(CosmicText::OneStyle("Output".into())),
+            attrs: PlaceholderAttrs(AttrsOwned::new(
+                Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
+            )),
+        })
+        .insert((ReadOnly, DisplayTag));
 }
 
 fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -104,12 +104,20 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
             );
         });
 
-    commands
+    let login_editor = commands
         .spawn(CosmicEditBundle {
             target: CosmicTarget(login_id),
             max_lines: CosmicMaxLines(1),
             metrics: CosmicMetrics {
                 scale_factor: window.scale_factor() as f32,
+                ..default()
+            },
+            sprite_bundle: SpriteBundle {
+                sprite: Sprite {
+                    custom_size: Some(Vec2::new(300.0, 50.0)),
+                    ..default()
+                },
+                visibility: Visibility::Hidden,
                 ..default()
             },
             ..default()
@@ -120,7 +128,8 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
                 Attrs::new().color(bevy_color_to_cosmic(Color::rgb_u8(128, 128, 128))),
             )),
         })
-        .insert(UsernameTag);
+        .insert(UsernameTag)
+        .id();
 
     commands
         .spawn(CosmicEditBundle {
@@ -176,6 +185,8 @@ fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
             )),
         })
         .insert((ReadOnly, DisplayTag));
+
+    commands.insert_resource(Focus(Some(login_editor)));
 }
 
 fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -20,16 +20,13 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
         scale_factor: primary_window.scale_factor() as f32,
     };
 
-    let cosmic_edit_1 = (
-        CosmicEditBundle {
-            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-            metrics: metrics.clone(),
-            text_position: CosmicTextPosition::Center,
-            fill_color: FillColor(Color::ALICE_BLUE),
-            text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
-            ..default()
-        },
-        SpriteBundle {
+    let cosmic_edit_1 = (CosmicEditBundle {
+        attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+        metrics: metrics.clone(),
+        text_position: CosmicTextPosition::Center,
+        fill_color: FillColor(Color::ALICE_BLUE),
+        text_setter: CosmicText::OneStyle("😀😀😀 x => y".to_string()),
+        sprite_bundle: SpriteBundle {
             sprite: Sprite {
                 custom_size: Some(Vec2 {
                     x: primary_window.width() / 2.,
@@ -40,18 +37,16 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             transform: Transform::from_translation(Vec3::new(-primary_window.width() / 4., 0., 1.)),
             ..default()
         },
-    );
+        ..default()
+    },);
 
-    let cosmic_edit_2 = (
-        CosmicEditBundle {
-            attrs: CosmicAttrs(AttrsOwned::new(attrs)),
-            metrics,
-            text_position: CosmicTextPosition::Center,
-            fill_color: FillColor(Color::GRAY.with_a(0.5)),
-            text_setter: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
-            ..default()
-        },
-        SpriteBundle {
+    let cosmic_edit_2 = (CosmicEditBundle {
+        attrs: CosmicAttrs(AttrsOwned::new(attrs)),
+        metrics,
+        text_position: CosmicTextPosition::Center,
+        fill_color: FillColor(Color::GRAY.with_a(0.5)),
+        text_setter: CosmicText::OneStyle("Widget_2. Click on me".to_string()),
+        sprite_bundle: SpriteBundle {
             sprite: Sprite {
                 custom_size: Some(Vec2 {
                     x: primary_window.width() / 2.,
@@ -66,7 +61,8 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             )),
             ..default()
         },
-    );
+        ..default()
+    },);
 
     let id = commands.spawn(cosmic_edit_1).id();
 

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -20,8 +20,9 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
     attrs = attrs.family(Family::Name("Victor Mono"));
     attrs = attrs.color(bevy_color_to_cosmic(Color::PURPLE));
 
-    let cosmic_edit = (
-        CosmicEditBundle {
+    // spawn editor
+    let cosmic_edit = commands
+        .spawn(CosmicEditBundle {
             attrs: CosmicAttrs(AttrsOwned::new(attrs)),
             text_position: CosmicTextPosition::Center,
             metrics: CosmicMetrics {
@@ -31,25 +32,27 @@ fn setup(mut commands: Commands, windows: Query<&Window, With<PrimaryWindow>>) {
             },
             text_setter: CosmicText::OneStyle("😀😀😀 x => y\nRead only widget".to_string()),
             ..default()
-        },
-        ButtonBundle {
-            style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
-                ..default()
-            },
-            background_color: BackgroundColor(Color::WHITE),
-            ..default()
-        },
-    );
+        })
+        .insert(ReadOnly)
+        .id();
 
-    let mut id = None;
-    // Spawn the CosmicEditUiBundle as a child of root
+    // Spawn the ButtonBundle as a child of root
     commands.entity(root).with_children(|parent| {
-        id = Some(parent.spawn(cosmic_edit).insert(ReadOnly).id());
+        parent
+            .spawn(ButtonBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                background_color: BackgroundColor(Color::WHITE),
+                ..default()
+            })
+            // add cosmic source
+            .insert(CosmicSource(cosmic_edit));
     });
 
-    commands.insert_resource(Focus(id));
+    commands.insert_resource(Focus(Some(cosmic_edit)));
 }
 
 pub fn bevy_color_to_cosmic(color: bevy::prelude::Color) -> CosmicColor {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,6 +1,6 @@
 use bevy::{input::mouse::MouseMotion, prelude::*, window::PrimaryWindow};
 
-use crate::{CosmicEditor, CosmicTextChanged};
+use crate::{CosmicEditor, CosmicSource, CosmicTextChanged};
 
 #[cfg(feature = "multicam")]
 use crate::CosmicPrimaryCamera;
@@ -82,7 +82,7 @@ pub fn hover_sprites(
 }
 
 pub fn hover_ui(
-    mut interaction_query: Query<&Interaction, (Changed<Interaction>, With<CosmicEditor>)>,
+    mut interaction_query: Query<&Interaction, (Changed<Interaction>, With<CosmicSource>)>,
     mut evw_hover_in: EventWriter<TextHoverIn>,
     mut evw_hover_out: EventWriter<TextHoverOut>,
 ) {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -45,7 +45,7 @@ type CameraQuery<'a, 'b, 'c, 'd> = Query<'a, 'b, (&'c Camera, &'d GlobalTransfor
 
 pub fn hover_sprites(
     windows: Query<&Window, With<PrimaryWindow>>,
-    mut cosmic_edit_query: Query<(&mut Sprite, &GlobalTransform), With<CosmicEditor>>,
+    mut cosmic_edit_query: Query<(&mut Sprite, &Visibility, &GlobalTransform), With<CosmicEditor>>,
     camera_q: CameraQuery,
     mut hovered: Local<bool>,
     mut last_hovered: Local<bool>,
@@ -55,8 +55,11 @@ pub fn hover_sprites(
     *hovered = false;
     let window = windows.single();
     let (camera, camera_transform) = camera_q.single();
-    for (sprite, node_transform) in &mut cosmic_edit_query.iter_mut() {
-        let size = sprite.custom_size.unwrap_or(Vec2::new(1., 1.));
+    for (sprite, visibility, node_transform) in &mut cosmic_edit_query.iter_mut() {
+        if visibility == Visibility::Hidden {
+            continue;
+        }
+        let size = sprite.custom_size.unwrap_or(Vec2::ONE);
         let x_min = node_transform.affine().translation.x - size.x / 2.;
         let y_min = node_transform.affine().translation.y - size.y / 2.;
         let x_max = node_transform.affine().translation.x + size.x / 2.;

--- a/src/input.rs
+++ b/src/input.rs
@@ -221,8 +221,6 @@ pub(crate) fn input_mouse(
 }
 
 // TODO: split copy/paste into own fn, separate fn for wasm
-// Maybe split undo/redo too, just drop inputs from this fn when pressed
-/// Handles undo/redo, copy/paste and char input
 pub(crate) fn input_kb(
     active_editor: Res<Focus>,
     keys: Res<Input<KeyCode>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ use input::{poll_wasm_paste, WasmPaste, WasmPasteAsyncChannel};
 use render::{
     blink_cursor, cosmic_edit_redraw_buffer, freeze_cursor_blink, hide_inactive_or_readonly_cursor,
     hide_password_text, on_scale_factor_change, restore_password_text, restore_placeholder_text,
-    set_initial_scale, show_placeholder, CursorBlinkTimer, CursorVisibility, PasswordValues,
-    SwashCacheState,
+    set_initial_scale, show_placeholder, CosmicPadding, CosmicWidgetSize, CursorBlinkTimer,
+    CursorVisibility, PasswordValues, SwashCacheState,
 };
 
 #[cfg(feature = "multicam")]
@@ -237,6 +237,9 @@ pub struct CosmicEditBundle {
     pub mode: CosmicMode,
     pub sprite_bundle: SpriteBundle,
     pub target: CosmicTarget,
+    // render bits
+    pub padding: CosmicPadding,
+    pub widget_size: CosmicWidgetSize,
 }
 
 impl Default for CosmicEditBundle {
@@ -260,6 +263,8 @@ impl Default for CosmicEditBundle {
                 ..default()
             },
             target: Default::default(),
+            padding: Default::default(),
+            widget_size: Default::default(),
         }
     }
 }
@@ -327,6 +332,16 @@ impl Plugin for CosmicEditPlugin {
             clear_inactive_selection,
         );
 
+        let render_ordered = (
+            render::cosmic_widget_size,
+            render::cosmic_buffer_size,
+            render::auto_height,
+            render::set_cursor,
+            render::cosmic_padding,
+            render::render_texture,
+        )
+            .chain();
+
         app.add_systems(
             First,
             (
@@ -351,7 +366,8 @@ impl Plugin for CosmicEditPlugin {
             (
                 hide_password_text,
                 show_placeholder,
-                cosmic_edit_redraw_buffer.after(TransformSystem::TransformPropagate),
+                render_ordered.after(TransformSystem::TransformPropagate),
+                //cosmic_edit_redraw_buffer.after(TransformSystem::TransformPropagate),
                 apply_deferred, // Prevents one-frame inputs adding placeholder to editor
                 restore_password_text,
                 restore_placeholder_text,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,8 +220,8 @@ impl Default for PasswordInput {
     }
 }
 
-#[derive(Component, Default)]
-pub struct CosmicTarget(pub Option<Entity>);
+#[derive(Component)]
+pub struct CosmicSource(pub Entity);
 
 #[derive(Bundle)]
 pub struct CosmicEditBundle {
@@ -236,7 +236,6 @@ pub struct CosmicEditBundle {
     pub text_setter: CosmicText,
     pub mode: CosmicMode,
     pub sprite_bundle: SpriteBundle,
-    pub target: CosmicTarget,
     // render bits
     pub padding: CosmicPadding,
     pub widget_size: CosmicWidgetSize,
@@ -262,7 +261,6 @@ impl Default for CosmicEditBundle {
                 visibility: Visibility::Hidden,
                 ..default()
             },
-            target: Default::default(),
             padding: Default::default(),
             widget_size: Default::default(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@ impl Plugin for CosmicEditPlugin {
 
         let render_ordered = (
             render::new_image_from_default,
+            render::set_size_from_ui,
             render::cosmic_reshape,
             render::cosmic_widget_size,
             render::cosmic_buffer_size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,9 +336,11 @@ impl Plugin for CosmicEditPlugin {
             render::cosmic_reshape.in_set(CosmicRenderSet::Shaping),
             render::cosmic_widget_size.in_set(CosmicRenderSet::Sizing),
             render::cosmic_buffer_size.in_set(CosmicRenderSet::Sizing),
-            render::auto_height.in_set(CosmicRenderSet::Sizing),
-            render::set_cursor.in_set(CosmicRenderSet::Cursor),
+            render::auto_height
+                .after(CosmicRenderSet::Sizing)
+                .before(CosmicRenderSet::Draw),
             render::cosmic_padding.in_set(CosmicRenderSet::Padding),
+            render::set_cursor.in_set(CosmicRenderSet::Cursor),
             render::render_texture.in_set(CosmicRenderSet::Draw),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,7 @@ impl Plugin for CosmicEditPlugin {
         );
 
         let render_ordered = (
+            render::new_image_from_default,
             render::cosmic_reshape,
             render::cosmic_widget_size,
             render::cosmic_buffer_size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,10 @@ use input::{input_kb, input_mouse, undo_redo, ClickTimer};
 #[cfg(target_arch = "wasm32")]
 use input::{poll_wasm_paste, WasmPaste, WasmPasteAsyncChannel};
 use render::{
-    blink_cursor, cosmic_edit_redraw_buffer, freeze_cursor_blink, hide_inactive_or_readonly_cursor,
-    hide_password_text, on_scale_factor_change, restore_password_text, restore_placeholder_text,
-    set_initial_scale, show_placeholder, CosmicPadding, CosmicWidgetSize, CursorBlinkTimer,
-    CursorVisibility, PasswordValues, SwashCacheState,
+    blink_cursor, freeze_cursor_blink, hide_inactive_or_readonly_cursor, hide_password_text,
+    on_scale_factor_change, restore_password_text, restore_placeholder_text, set_initial_scale,
+    show_placeholder, CosmicPadding, CosmicWidgetSize, CursorBlinkTimer, CursorVisibility,
+    PasswordValues, SwashCacheState,
 };
 
 #[cfg(feature = "multicam")]
@@ -333,6 +333,7 @@ impl Plugin for CosmicEditPlugin {
         );
 
         let render_ordered = (
+            render::cosmic_reshape,
             render::cosmic_widget_size,
             render::cosmic_buffer_size,
             render::auto_height,

--- a/src/render.rs
+++ b/src/render.rs
@@ -78,6 +78,13 @@ pub(crate) fn cosmic_edit_redraw_buffer(
 
         editor.shape_as_needed(&mut font_system.0);
 
+        // TODO: set w/h in CosmicEditor struct / Bundle, then set sprite size or styles in a
+        // Query<&mut Style, (Added<Style>, With<CosmicEditor>> system
+        //
+        // TODO: This function should not care about destination, simply render to texture and let
+        // other systems use texture how they like. Separate system for sizing texture to target
+        // width/height. May allow shaders to finally be used.
+
         // Get numbers, do maths to find and set cursor
         //
         let (base_width, mut base_height) = match node_opt {
@@ -87,16 +94,18 @@ pub(crate) fn cosmic_edit_redraw_buffer(
                 sprite_opt.as_ref().unwrap().custom_size.unwrap().y.ceil(),
             ),
         };
-
+        // TODO: cache these numbers, no need to recalc if no underlying changes
         let widget_width = base_width * scale;
         let widget_height = base_height * scale;
 
+        // TODO: Split positioning out, store padding in component
         let padding_x = match text_position {
             CosmicTextPosition::Center => 0.,
             CosmicTextPosition::TopLeft { padding } => *padding as f32,
             CosmicTextPosition::Left { padding } => *padding as f32,
         };
 
+        // TODO: Split modes out, store results in component
         let (buffer_width, buffer_height) = match mode {
             CosmicMode::InfiniteLine => (f32::MAX, widget_height),
             CosmicMode::AutoHeight => (widget_width - padding_x, (i32::MAX / 2) as f32),
@@ -107,6 +116,8 @@ pub(crate) fn cosmic_edit_redraw_buffer(
             .buffer_mut()
             .set_size(&mut font_system.0, buffer_width, buffer_height);
 
+        // TODO: AutoHeight adjustment should be it's own system
+        // Currently works with a 1 frame delay if I'm reading the code right
         if mode == &CosmicMode::AutoHeight {
             let text_size = get_text_size(editor.buffer());
             let text_height = (text_size.1 + 30.) / primary_window.scale_factor() as f32;
@@ -188,6 +199,7 @@ pub(crate) fn cosmic_edit_redraw_buffer(
         }
 
         // Get values for glyph draw step
+        // TODO: will come from padding component, set in positioning system
         let (padding_x, padding_y) = match text_position {
             CosmicTextPosition::Center => (
                 get_x_offset_center(widget_width, editor.buffer()),
@@ -228,6 +240,8 @@ pub(crate) fn cosmic_edit_redraw_buffer(
 
         let canvas = &mut canvas.0;
 
+        // TODO: set CosmicCanvas default value to a new image, expect it here instead of checking
+        // for `DEFAULT_IMAGE_HANDLE`
         if let Some(prev_image) = images.get_mut(canvas) {
             if *canvas == bevy::render::texture::DEFAULT_IMAGE_HANDLE.typed() {
                 let mut prev_image = prev_image.clone();

--- a/src/render.rs
+++ b/src/render.rs
@@ -277,10 +277,7 @@ pub(crate) fn set_cursor(
 }
 
 pub(crate) fn auto_height(
-    mut query: Query<
-        (&mut Sprite, &CosmicMode, &CosmicEditor, &CosmicWidgetSize),
-        Changed<CosmicEditor>,
-    >,
+    mut query: Query<(&mut Sprite, &CosmicMode, &CosmicEditor, &CosmicWidgetSize)>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
     let scale = windows.single().scale_factor() as f32;
@@ -299,7 +296,7 @@ pub(crate) fn auto_height(
 
 pub(crate) fn set_size_from_ui(
     mut source_q: Query<&mut Sprite, With<CosmicEditor>>,
-    dest_q: Query<(&Node, &CosmicSource), Changed<Node>>,
+    dest_q: Query<(&Node, &CosmicSource)>,
 ) {
     for (node, source) in dest_q.iter() {
         if let Ok(mut sprite) = source_q.get_mut(source.0) {

--- a/src/render.rs
+++ b/src/render.rs
@@ -201,7 +201,7 @@ pub(crate) fn render_texture(
             },
         );
 
-        if let Some(prev_image) = images.get_mut(&canvas) {
+        if let Some(prev_image) = images.get_mut(canvas) {
             prev_image.data.clear();
             prev_image.data.extend_from_slice(pixels.as_slice());
             prev_image.resize(Extent3d {

--- a/src/render.rs
+++ b/src/render.rs
@@ -287,8 +287,18 @@ pub(crate) fn auto_height(
     }
 }
 
-pub(crate) fn set_size_from_ui() {
-    // TODO
+pub(crate) fn set_size_from_ui(
+    mut source_q: Query<(&mut Sprite, &CosmicTarget)>,
+    dest_q: Query<&Node>,
+) {
+    for (mut sprite, target) in source_q.iter_mut() {
+        if target.0.is_none() {
+            continue;
+        }
+        if let Ok(node) = dest_q.get(target.0.unwrap()) {
+            sprite.custom_size = Some(node.size().ceil());
+        }
+    }
 }
 
 pub(crate) fn set_size_from_mesh() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -296,7 +296,7 @@ pub(crate) fn set_size_from_ui(
             continue;
         }
         if let Ok(node) = dest_q.get(target.0.unwrap()) {
-            sprite.custom_size = Some(node.size().ceil());
+            sprite.custom_size = Some(node.size().ceil().max(Vec2::ONE));
         }
     }
 }


### PR DESCRIPTION
Moving this to it's own PR as it's gonna be a fair bit of changes not related to the 3D bits :)

- [x] Main function should just draw to target texture
- [x] Separate texture resizing systems
- [x] Render to sprite by default
- [x] Separate image creation system (in case of `DEFAULT_IMAGE_HANDLE`)
- [x] Separate `CosmicTextPosition` systems
- [x] Separate `CosmicTextMode` systems
~Cache calculated `widget_width` & `widget_height`, update when any relevant values change~
    Need to learn a bit more about when mutable derefs happen in Bevy to correctly use `Changed<Component>`
- [x] Put all mentioned systems into a rendering `SystemSet`
- [x] Test with system ordering in mind
- [x] Fix padding when typing
- [x] Restore click & drag functionality
- [x] Fix cursor changing when hovered over unrendered sprite position
- [x] Update & test examples
- [x] Fix autoheight not setting target size when used in UI element
~bug: text_input example adds E when pressing enter on wasm
    systems ordering issue~ #107 
~bug: ReadOnly inputs can still receive backspace inputs on wasm~ #108
~padding is inconsistent (in text_input)~ #109