### PR TITLE
internal placeholder plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## Version 0.18.0 (2024)
+
+- Add text placeholder plugin
+
 ## Version 0.17.0 (2024)
 
 - Update to cosmic-text 0.11.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cosmic_edit"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["assets/*"]
 
 [features]
 multicam = []
+placeholder = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -43,8 +44,12 @@ arboard = "3.2.0"
 js-sys = "0.3.67"
 wasm-bindgen = "0.2.92"
 wasm-bindgen-futures = "0.4.42"
-web-sys = { version = "0.3.67", features = ["Clipboard", "Navigator", "Window"] }
+web-sys = { version = "0.3.67", features = [
+  "Clipboard",
+  "Navigator",
+  "Window",
+] }
 
 [dev-dependencies]
 insta = "1.29.0"
-util = {path="./util/"}
+util = { path = "./util/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["util"] }
 [package]
 name = "bevy_cosmic_edit"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Bevy cosmic-text multiline text input"

--- a/examples/placeholder.rs
+++ b/examples/placeholder.rs
@@ -27,11 +27,10 @@ fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
                     text_position: CosmicTextPosition::Center,
                     ..default()
                 },
-                Placeholder {
-                    active: false,
-                    attrs: attrs.color(bevy_color_to_cosmic(Color::GRAY)),
-                    text: "Placeholder",
-                },
+                Placeholder::new(
+                    "Placeholder",
+                    attrs.color(bevy_color_to_cosmic(Color::GRAY)),
+                ),
             ))
             .id();
 

--- a/examples/placeholder.rs
+++ b/examples/placeholder.rs
@@ -52,8 +52,6 @@ fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
         // Plugin looks for UiImage and sets it's
         // texture to the editor's rendered image
         .insert(CosmicSource(cosmic_edit));
-
-    commands.insert_resource(FocusedWidget(Some(cosmic_edit)));
 }
 
 fn main() {

--- a/examples/placeholder.rs
+++ b/examples/placeholder.rs
@@ -1,0 +1,83 @@
+use bevy::prelude::*;
+use bevy_cosmic_edit::{placeholder::Placeholder, *};
+use util::{
+    bevy_color_to_cosmic, change_active_editor_ui, deselect_editor_on_esc, print_editor_text,
+};
+
+fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
+    let camera_bundle = Camera2dBundle {
+        camera: Camera {
+            clear_color: ClearColorConfig::Custom(Color::PINK),
+            ..default()
+        },
+        ..default()
+    };
+    commands.spawn(camera_bundle);
+
+    let mut attrs = Attrs::new();
+    attrs = attrs.family(Family::Name("Victor Mono"));
+    attrs = attrs.color(CosmicColor::rgb(0x94, 0x00, 0xD3));
+
+    let cosmic_edit =
+        commands
+            .spawn((
+                CosmicEditBundle {
+                    buffer: CosmicBuffer::new(&mut font_system, Metrics::new(20., 20.))
+                        .with_rich_text(&mut font_system, vec![("", attrs)], attrs),
+                    text_position: CosmicTextPosition::Center,
+                    ..default()
+                },
+                Placeholder {
+                    active: false,
+                    attrs: attrs.color(bevy_color_to_cosmic(Color::GRAY)),
+                    text: "Placeholder",
+                },
+            ))
+            .id();
+
+    commands
+        .spawn(
+            // Use buttonbundle for layout
+            // Includes Interaction and UiImage which are used by the plugin.
+            ButtonBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    ..default()
+                },
+                ..default()
+            },
+        )
+        // point editor at this entity.
+        // Plugin looks for UiImage and sets it's
+        // texture to the editor's rendered image
+        .insert(CosmicSource(cosmic_edit));
+
+    commands.insert_resource(FocusedWidget(Some(cosmic_edit)));
+}
+
+fn main() {
+    let font_bytes: &[u8] = include_bytes!("../assets/fonts/VictorMono-Regular.ttf");
+    let font_config = CosmicFontConfig {
+        fonts_dir_path: None,
+        font_bytes: Some(vec![font_bytes]),
+        load_system_fonts: true,
+    };
+
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(CosmicEditPlugin {
+            font_config,
+            ..default()
+        })
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (
+                print_editor_text,
+                change_active_editor_ui,
+                deselect_editor_on_esc,
+            ),
+        )
+        .run();
+}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -15,8 +15,6 @@ impl<'s, 'r> CosmicBuffer {
         Self(Buffer::new(font_system, metrics))
     }
 
-    // TODO: Set redraw when setting text
-
     // Das a lotta boilerplate just to hide the shaping argument
     pub fn with_text(
         mut self,

--- a/src/input.rs
+++ b/src/input.rs
@@ -310,7 +310,6 @@ pub(crate) fn input_kb(
         }
         if should_jump && keys.just_pressed(KeyCode::Home) {
             editor.action(&mut font_system.0, Action::Motion(Motion::BufferStart));
-            editor.set_redraw(true);
             if !shift {
                 editor.set_selection(Selection::None);
             }
@@ -318,7 +317,6 @@ pub(crate) fn input_kb(
         }
         if should_jump && keys.just_pressed(KeyCode::End) {
             editor.action(&mut font_system.0, Action::Motion(Motion::BufferEnd));
-            editor.set_redraw(true);
             if !shift {
                 editor.set_selection(Selection::None);
             }
@@ -534,7 +532,6 @@ pub(crate) fn input_kb(
                     for c in b {
                         let c: char = (*c).into();
                         editor.action(&mut font_system.0, Action::Insert(c));
-                        editor.set_redraw(true);
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,13 @@ mod input;
 mod layout;
 mod render;
 
+mod plugins;
+pub use plugins::*;
+
 use std::{path::PathBuf, time::Duration};
 
 use bevy::{prelude::*, transform::TransformSystem};
+
 use buffer::{
     add_font_system, set_editor_redraw, set_initial_scale, set_redraw, swap_target_handle,
 };
@@ -264,7 +268,16 @@ impl Plugin for CosmicEditPlugin {
             app.insert_resource(WasmPasteAsyncChannel { tx, rx })
                 .add_systems(Update, poll_wasm_paste);
         }
+
+        add_feature_plugins(app);
     }
+}
+
+fn add_feature_plugins(app: &mut App) -> &mut App {
+    #[cfg(feature = "placeholder")]
+    app.add_plugins(plugins::placeholder::PlaceholderPlugin);
+
+    app
 }
 
 fn create_cosmic_font_system(cosmic_font_config: CosmicFontConfig) -> FontSystem {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,9 @@ impl Default for CosmicFontConfig {
     }
 }
 
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KbInput;
+
 /// Plugin struct that adds systems and initializes resources related to cosmic edit functionality.
 #[derive(Default)]
 pub struct CosmicEditPlugin {
@@ -228,7 +231,10 @@ impl Plugin for CosmicEditPlugin {
                 .chain(),
         )
         .add_systems(PreUpdate, (input_mouse,).chain())
-        .add_systems(Update, (input_kb, reshape, blink_cursor).chain())
+        .add_systems(
+            Update,
+            (input_kb, reshape, blink_cursor).chain().in_set(KbInput),
+        )
         .add_systems(
             PostUpdate,
             (

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "placeholder")]
+pub mod placeholder;

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -106,6 +106,26 @@ fn remove_placeholder_on_input(
             if new_string.is_empty() {
                 return new_string;
             }
+
+            {
+                // begin hacky fix for delete key in empty placeholder widget
+
+                // TODO: test and probably fix to account for multi-byte chars
+                let p = placeholder.text.chars().next().unwrap();
+
+                let laceholder = placeholder.text.strip_prefix(p).unwrap();
+
+                if new_string.as_str() == laceholder {
+                    b.set_text(
+                        &mut font_system,
+                        placeholder.text,
+                        placeholder.attrs,
+                        cosmic_text::Shaping::Advanced,
+                    );
+                    return String::new();
+                }
+            } // end hacky fix
+
             b.set_text(
                 &mut font_system,
                 new_string.as_str(),

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -28,9 +28,11 @@ impl Plugin for PlaceholderPlugin {
             Update,
             (
                 add_placeholder_to_buffer,
+                add_placeholder_to_editor,
                 move_cursor_to_start_of_placeholder,
                 remove_placeholder_on_input,
-            ),
+            )
+                .chain(),
         );
     }
 }
@@ -44,6 +46,26 @@ fn add_placeholder_to_buffer(
             buffer.set_text(&mut font_system, placeholder.text, placeholder.attrs);
             placeholder.active = true;
         }
+    }
+}
+
+fn add_placeholder_to_editor(
+    mut q: Query<(&mut CosmicEditor, &mut Placeholder)>,
+    mut font_system: ResMut<CosmicFontSystem>,
+) {
+    for (mut editor, mut placeholder) in q.iter_mut() {
+        editor.with_buffer_mut(|buffer| {
+            if buffer.lines[0].clone().into_text().is_empty() {
+                buffer.set_text(
+                    &mut font_system,
+                    placeholder.text,
+                    placeholder.attrs,
+                    cosmic_text::Shaping::Advanced,
+                );
+                placeholder.active = true;
+                buffer.set_redraw(true);
+            }
+        })
     }
 }
 

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -42,6 +42,10 @@ fn add_placeholder_to_buffer(
     mut font_system: ResMut<CosmicFontSystem>,
 ) {
     for (mut buffer, mut placeholder) in q.iter_mut() {
+        if placeholder.active {
+            return;
+        }
+
         if buffer.get_text().is_empty() {
             buffer.set_text(&mut font_system, placeholder.text, placeholder.attrs);
             placeholder.active = true;
@@ -54,6 +58,10 @@ fn add_placeholder_to_editor(
     mut font_system: ResMut<CosmicFontSystem>,
 ) {
     for (mut editor, mut placeholder) in q.iter_mut() {
+        if placeholder.active {
+            return;
+        }
+
         editor.with_buffer_mut(|buffer| {
             if buffer.lines[0].clone().into_text().is_empty() {
                 buffer.set_text(

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -68,7 +68,7 @@ fn remove_placeholder_on_input(
             return;
         }
 
-        editor.with_buffer_mut(|b| {
+        let new_string = editor.with_buffer_mut(|b| {
             let new_string = b.lines[0].clone().into_text().replace(placeholder.text, "");
             b.set_text(
                 &mut font_system,
@@ -76,9 +76,9 @@ fn remove_placeholder_on_input(
                 attrs.0.as_attrs(),
                 cosmic_text::Shaping::Advanced,
             );
+            new_string
         });
-        // TODO: multi byte char test
-        editor.set_cursor(cosmic_text::Cursor::new(0, 1));
+        editor.set_cursor(cosmic_text::Cursor::new(0, new_string.bytes().len()));
 
         placeholder.active = false;
     }

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -127,7 +127,7 @@ fn remove_placeholder_on_input(
                 if lines > 2 {
                     // for pasted text, remove trailing newline
                     full_text = full_text
-                        .strip_suffix("\n")
+                        .strip_suffix('\n')
                         .expect("oop something broke in multiline placeholder removal")
                         .to_string();
                 }
@@ -141,10 +141,7 @@ fn remove_placeholder_on_input(
 
                 let last_line = full_text.lines().last();
 
-                return match last_line {
-                    Some(line) => Some(line.to_string()),
-                    None => None,
-                };
+                return last_line.map(|line| line.to_string());
             }
 
             let single_line = b.lines[0].clone().into_text().replace(placeholder.text, "");

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -42,15 +42,16 @@ fn empty_editor_buffer_on_focus(
     // TODO: In order to hold placeholder until input, move XOffset to 0 and empty buffer on input
     for (mut editor, mut placeholder, attrs) in q.iter_mut() {
         if placeholder.active {
+            placeholder.active = false;
             editor.with_buffer_mut(|b| {
                 b.set_text(
                     &mut font_system,
                     "",
                     attrs.0.as_attrs(),
                     cosmic_text::Shaping::Advanced,
-                )
+                );
             });
-            placeholder.active = false;
+            editor.set_cursor(cosmic_text::Cursor::new(0, 0));
         }
     }
 }

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -1,7 +1,9 @@
 use bevy::prelude::*;
 use cosmic_text::{Attrs, Edit};
 
-use crate::{CosmicBuffer, CosmicEditor, CosmicFontSystem, CosmicTextChanged, DefaultAttrs};
+use crate::{
+    CosmicBuffer, CosmicEditor, CosmicFontSystem, CosmicTextChanged, DefaultAttrs, KbInput,
+};
 
 #[derive(Component)]
 pub struct Placeholder {
@@ -32,7 +34,8 @@ impl Plugin for PlaceholderPlugin {
                 move_cursor_to_start_of_placeholder,
                 remove_placeholder_on_input,
             )
-                .chain(),
+                .chain()
+                .after(KbInput),
         );
     }
 }
@@ -100,6 +103,9 @@ fn remove_placeholder_on_input(
 
         let new_string = editor.with_buffer_mut(|b| {
             let new_string = b.lines[0].clone().into_text().replace(placeholder.text, "");
+            if new_string.is_empty() {
+                return new_string;
+            }
             b.set_text(
                 &mut font_system,
                 new_string.as_str(),
@@ -108,6 +114,11 @@ fn remove_placeholder_on_input(
             );
             new_string
         });
+
+        if new_string.is_empty() {
+            return;
+        }
+
         editor.set_cursor(cosmic_text::Cursor::new(0, new_string.bytes().len()));
 
         placeholder.active = false;

--- a/src/plugins/placeholder/mod.rs
+++ b/src/plugins/placeholder/mod.rs
@@ -7,15 +7,23 @@ use crate::{CosmicBuffer, CosmicEditor, CosmicFontSystem, DefaultAttrs};
 pub struct Placeholder {
     pub text: &'static str,
     pub attrs: Attrs<'static>,
-    pub active: bool,
+    active: bool,
+}
+
+impl Placeholder {
+    pub fn new(text: impl Into<&'static str>, attrs: Attrs<'static>) -> Self {
+        Self {
+            active: false,
+            text: text.into(),
+            attrs,
+        }
+    }
 }
 
 pub struct PlaceholderPlugin;
 
 impl Plugin for PlaceholderPlugin {
     fn build(&self, app: &mut App) {
-        info!("PlaceholderPlugin loaded.");
-
         app.add_systems(
             Update,
             (add_placeholder_to_buffer, empty_editor_buffer_on_focus),


### PR DESCRIPTION
- [x] Hold placeholder in editor until input, keeping text cursor visible at beginning of placeholder
- [x] Test WASM
- [x] Fix panic when typing in empty placeholder editor
- [x] Pass CI (more liberal use of `cfg` or change CI command to include all features?) #126
- [x] Allow multi-byte chars to be first input

Currently removes placeholder on interaction, whereas most placeholders react when there is input. This approach is a quick and dirty proof of concept so far.

@StaffEngineer please let me know what you think of this method of adding plugins. Gating behind feature flags and such.

I'm not sure whether to add them in the main `CosmicEditPlugin` or leave it to the user to add the feature plugins. User-added is better for plugin-specific configurability, but at the cost of less "it just works".

To test, run `cargo r --features placeholder --example placeholder`