### PR TITLE
add --all-features to CI checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
       - name: Check
-        run: cargo check --all-targets
+        run: cargo check --all-features --all-targets
   check-wasm:
     name: Check wasm
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
       - name: Check
-        run: RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown --all-targets
+        run: RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --all-features --target wasm32-unknown-unknown --all-targets
   lints:
     name: Lints
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
  
-      - name: Test bevy-markdown
+      - name: Test bevy_cosmic_edit
         run: cargo test -p bevy_cosmic_edit --lib
   # coverage:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
I'm not experienced with CI, but if we're using feature flags and providing examples that use them this might be the solution to pass checks, and keep CI coverage across features

Helps with #125 passing tests