### PR TITLE
fix autofocus breaking due to system ordering

### DIFF
--- a/src/focus.rs
+++ b/src/focus.rs
@@ -13,7 +13,8 @@ impl Plugin for FocusPlugin {
             PostUpdate,
             (drop_editor_unfocused, add_editor_to_focused)
                 .chain()
-                .in_set(FocusSet),
+                .in_set(FocusSet)
+                .after(WidgetSet),
         )
         .init_resource::<FocusedWidget>();
     }


### PR DESCRIPTION
parallelism and concurrency is hard. this fixes a bug where text would not display on a widget if it is focused in startup (again)