### PR TITLE
dont remove editor while password blockers active

### DIFF
--- a/src/password.rs
+++ b/src/password.rs
@@ -22,7 +22,7 @@ impl Plugin for PasswordPlugin {
                 PostUpdate,
                 (
                     hide_password_text.before(RenderSet).in_set(PasswordSet),
-                    restore_password_text.after(RenderSet),
+                    restore_password_text.before(FocusSet).after(RenderSet),
                 ),
             );
     }


### PR DESCRIPTION
fixes a bug where the password field could replace it's contents with blocker glyphs if the widget was unfocused at the wrong time