### PR TITLE
import missing `AttrsOwned` field types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,8 +100,9 @@ pub use buffer::*;
 pub use cosmic_edit::*;
 #[doc(no_inline)]
 pub use cosmic_text::{
-    Action, Attrs, AttrsOwned, Buffer, Color as CosmicColor, Cursor, Edit, Editor, Family,
-    FontSystem, Metrics, Shaping, Style as FontStyle, Weight as FontWeight,
+    Action, Attrs, AttrsOwned, Buffer, CacheKeyFlags, Color as CosmicColor, Cursor, Edit, Editor,
+    Family, FamilyOwned, FontSystem, Metrics, Shaping, Stretch, Style as FontStyle,
+    Weight as FontWeight,
 };
 pub use cursor::*;
 pub use events::*;


### PR DESCRIPTION
since `DefaultAttrs` is just a component wrapper for `pub AttrsOwned` it's useful for downstream libraries to have access to the `AttrOwned` field types for any functions that may forward values into `DefaultAttrs`, without having to manage extra dependencies

the PR adds
- `FamilyOwned`
- `Stretch`
- `CacheKeyFlags`