### PR TITLE
Use `std::sync::Arc<cosmic-text::Buffer>` in bevy component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_cosmic_edit"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arboard",
  "bevy",

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::*;
 use bevy::{prelude::*, render::render_resource::Extent3d};
 use cosmic_text::{Color, Edit, SwashCache};
@@ -215,7 +217,8 @@ fn render_texture(
                 font_color,
                 draw_closure,
             );
-            buffer.set_redraw(false);
+            let buffer_mut = Arc::make_mut(&mut buffer.0);
+            buffer_mut.set_redraw(false);
         }
 
         if let Some(prev_image) = images.get_mut(canvas) {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -68,7 +68,15 @@ fn set_padding(
     >,
 ) {
     for (mut padding, position, buffer, size, editor_opt) in query.iter_mut() {
-        if !buffer.redraw() {
+        let mut redraw = buffer.redraw();
+        let mut buffer = buffer.0.as_ref().clone();
+
+        if let Some(editor) = editor_opt {
+            redraw = editor.redraw();
+            buffer = editor.with_buffer(|b| b.clone());
+        }
+
+        if !redraw {
             continue;
         }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::*;
 use bevy::{prelude::*, window::PrimaryWindow};
 use cosmic_text::Affinity;
@@ -66,13 +68,6 @@ fn set_padding(
     >,
 ) {
     for (mut padding, position, buffer, size, editor_opt) in query.iter_mut() {
-        // TODO: At least one of these clones is uneccessary
-        let mut buffer = buffer.0.clone();
-
-        if let Some(editor) = editor_opt {
-            buffer = editor.with_buffer(|b| b.clone());
-        }
-
         if !buffer.redraw() {
             continue;
         }
@@ -134,6 +129,8 @@ fn set_buffer_size(
             CosmicWrap::InfiniteLine => (f32::MAX, size.0.y),
             CosmicWrap::Wrap => (size.0.x - padding_x, size.0.y),
         };
+
+        let buffer = Arc::make_mut(&mut buffer);
 
         buffer.set_size(&mut font_system.0, buffer_width, buffer_height);
     }


### PR DESCRIPTION
I'm not too sure about using `make_mut` whenever modification to the buffer is needed, as I don't have the best understanding of copy-on-write and how that will work, though I'd like to think bevy's scheduler will prevent race conditions.

Needs a fair bit more testing, but this change should remove the need for double checking the editor buffer everywhere there could be two, as there is now one buffer per widget.

Fixes #145
Fixes #138 (untested so far)