### PR TITLE
Upgrade web-sys/js-sys to 0.3.70, fix compile error with `Clipboard`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,9 +2139,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3803,19 +3803,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -3840,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3850,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3863,15 +3864,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,17 @@ multicam = []
 
 [dependencies]
 bevy = { version = "0.14", default-features = false, features = [
-  "bevy_asset",
-  "bevy_core_pipeline",
-  "bevy_render",
-  "bevy_scene",
-  "bevy_sprite",
-  "bevy_text",
-  "bevy_ui",
-  "bevy_winit",
-  "png",
-  "x11",
-  "webgpu",
+    "bevy_asset",
+    "bevy_core_pipeline",
+    "bevy_render",
+    "bevy_scene",
+    "bevy_sprite",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_winit",
+    "png",
+    "x11",
+    "webgpu",
 ] }
 cosmic-text = { version = "0.12.0" }
 # TODO: move crossbeam to wasm32, once input.rs has separate wasm copy/paste fn
@@ -44,13 +44,13 @@ document-features = "0.2.8"
 arboard = "3.2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.67"
+js-sys = "0.3.70"
 wasm-bindgen = "0.2.92"
 wasm-bindgen-futures = "0.4.42"
-web-sys = { version = "0.3.67", features = [
-  "Clipboard",
-  "Navigator",
-  "Window",
+web-sys = { version = "0.3.70", features = [
+    "Clipboard",
+    "Navigator",
+    "Window",
 ] }
 
 [dev-dependencies]

--- a/src/input.rs
+++ b/src/input.rs
@@ -654,22 +654,14 @@ fn keypress_command(keys: &ButtonInput<KeyCode>) -> bool {
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn write_clipboard_wasm(text: &str) {
-    let clipboard = web_sys::window()
-        .unwrap()
-        .navigator()
-        .clipboard()
-        .expect("Clipboard not found!");
+    let clipboard = web_sys::window().unwrap().navigator().clipboard();
     let _result = clipboard.write_text(text);
 }
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn read_clipboard_wasm() -> Promise {
-    let clipboard = web_sys::window()
-        .unwrap()
-        .navigator()
-        .clipboard()
-        .expect("Clipboard not found!");
+    let clipboard = web_sys::window().unwrap().navigator().clipboard();
     clipboard.read_text()
 }
 


### PR DESCRIPTION
Compiling to wasm32 currently fails because of a bug in the currently pinned version of web-sys that doesn't recognize the `Clipboard` feature flag. This upgrades web-sys/js-sys to the latest version, and makes a small change to account for the change in the `Clipboard` API, which no longer returns a `Result`.