### PR TITLE
public import cosmic text

### DIFF
--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, window::PrimaryWindow};
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
 
 fn setup(
     mut commands: Commands,

--- a/examples/basic_sprite.rs
+++ b/examples/basic_sprite.rs
@@ -1,5 +1,8 @@
 use bevy::{prelude::*, window::PrimaryWindow};
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, Family, Metrics},
+    *,
+};
 
 fn setup(
     mut commands: Commands,

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, Family, Metrics},
+    *,
+};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     let camera_bundle = Camera2dBundle {

--- a/examples/basic_ui.rs
+++ b/examples/basic_ui.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     let camera_bundle = Camera2dBundle {

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, AttrsOwned, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, AttrsOwned, Metrics},
+    *,
+};
 
 #[derive(Resource)]
 struct TextChangeTimer(pub Timer);

--- a/examples/every_option.rs
+++ b/examples/every_option.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, AttrsOwned, Metrics}};
 
 #[derive(Resource)]
 struct TextChangeTimer(pub Timer);

--- a/examples/font_per_widget.rs
+++ b/examples/font_per_widget.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::type_complexity)]
 
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, Family, Metrics},
+    *,
+};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/font_per_widget.rs
+++ b/examples/font_per_widget.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/image_background.rs
+++ b/examples/image_background.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, AttrsOwned}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, AttrsOwned},
+    *,
+};
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/image_background.rs
+++ b/examples/image_background.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, AttrsOwned}};
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, window::PrimaryWindow};
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
 
 fn setup(
     mut commands: Commands,

--- a/examples/multiple_sprites.rs
+++ b/examples/multiple_sprites.rs
@@ -1,5 +1,8 @@
 use bevy::{prelude::*, window::PrimaryWindow};
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, Family, Metrics},
+    *,
+};
 
 fn setup(
     mut commands: Commands,

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::Attrs};
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::Attrs};
+use bevy_cosmic_edit::{cosmic_text::Attrs, *};
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/placeholder.rs
+++ b/examples/placeholder.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, Family, Metrics},
+    *,
+};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     let camera_bundle = Camera2dBundle {

--- a/examples/placeholder.rs
+++ b/examples/placeholder.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     let camera_bundle = Camera2dBundle {

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/readonly.rs
+++ b/examples/readonly.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, Family, Metrics}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, Family, Metrics},
+    *,
+};
 
 fn setup(mut commands: Commands, mut font_system: ResMut<CosmicFontSystem>) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/sprite_and_ui_clickable.rs
+++ b/examples/sprite_and_ui_clickable.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::*;
+use bevy_cosmic_edit::{*, cosmic_text::{Attrs, AttrsOwned}};
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/sprite_and_ui_clickable.rs
+++ b/examples/sprite_and_ui_clickable.rs
@@ -1,5 +1,8 @@
 use bevy::prelude::*;
-use bevy_cosmic_edit::{*, cosmic_text::{Attrs, AttrsOwned}};
+use bevy_cosmic_edit::{
+    cosmic_text::{Attrs, AttrsOwned},
+    *,
+};
 
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use bevy::{prelude::*, window::PrimaryWindow};
+use cosmic_text::{Attrs, AttrsOwned, Buffer, Edit, FontSystem, Metrics, Shaping};
 
 /// Set of all buffer setup functions. Runs in [`First`]
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/cosmic_edit.rs
+++ b/src/cosmic_edit.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use bevy::prelude::*;
+use cosmic_text::{Attrs, AttrsOwned, Editor, FontSystem};
 
 /// Enum representing text wrapping in a cosmic [`Buffer`]
 #[derive(Clone, Component, PartialEq, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,7 @@ use bevy::prelude::*;
 pub use buffer::*;
 pub use cosmic_edit::*;
 #[doc(no_inline)]
-pub use cosmic_text::{
-    Action, Attrs, AttrsOwned, Buffer, CacheKeyFlags, Color as CosmicColor, Cursor, Edit, Editor,
-    Family, FamilyOwned, FontSystem, Metrics, Shaping, Stretch, Style as FontStyle,
-    Weight as FontWeight,
-};
+pub use cosmic_text::{self, Color as CosmicColor, Style as FontStyle, Weight as FontWeight};
 pub use cursor::*;
 pub use events::*;
 pub use focus::*;
@@ -205,7 +201,7 @@ impl Default for CosmicFontConfig {
     }
 }
 
-fn create_cosmic_font_system(cosmic_font_config: CosmicFontConfig) -> FontSystem {
+fn create_cosmic_font_system(cosmic_font_config: CosmicFontConfig) -> cosmic_text::FontSystem {
     let locale = sys_locale::get_locale().unwrap_or_else(|| String::from("en-US"));
     let mut db = cosmic_text::fontdb::Database::new();
     if let Some(dir_path) = cosmic_font_config.fonts_dir_path.clone() {
@@ -234,9 +230,9 @@ mod tests {
         mut commands: Commands,
         mut font_system: ResMut<CosmicFontSystem>,
     ) {
-        let attrs = Attrs::new();
+        let attrs = cosmic_text::Attrs::new();
         commands.spawn(CosmicEditBundle {
-            buffer: CosmicBuffer::new(&mut font_system, Metrics::new(20., 20.)).with_rich_text(
+            buffer: CosmicBuffer::new(&mut font_system, cosmic_text::Metrics::new(20., 20.)).with_rich_text(
                 &mut font_system,
                 vec![("Blah", attrs)],
                 attrs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,11 +232,8 @@ mod tests {
     ) {
         let attrs = cosmic_text::Attrs::new();
         commands.spawn(CosmicEditBundle {
-            buffer: CosmicBuffer::new(&mut font_system, cosmic_text::Metrics::new(20., 20.)).with_rich_text(
-                &mut font_system,
-                vec![("Blah", attrs)],
-                attrs,
-            ),
+            buffer: CosmicBuffer::new(&mut font_system, cosmic_text::Metrics::new(20., 20.))
+                .with_rich_text(&mut font_system, vec![("Blah", attrs)], attrs),
             ..Default::default()
         });
     }

--- a/src/user_select.rs
+++ b/src/user_select.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use bevy::prelude::*;
+use cosmic_text::Edit;
 
 pub(crate) struct UserSelectPlugin;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 // Common functions for examples
 use crate::*;
 use bevy::{prelude::*, window::PrimaryWindow};
+use cosmic_text::Edit;
 
 /// Trait for adding color conversion from [`bevy::prelude::Color`] to [`cosmic_text::Color`]
 pub trait ColorExtras {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use cosmic_text::Edit;
 use bevy::{prelude::*, window::PrimaryWindow};
 use cosmic_text::Affinity;
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,7 +1,7 @@
 use crate::*;
-use cosmic_text::Edit;
 use bevy::{prelude::*, window::PrimaryWindow};
 use cosmic_text::Affinity;
+use cosmic_text::Edit;
 
 /// System set for cosmic text layout systems. Runs in [`PostUpdate`]
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
i needed some more `cosmic_text` stuff and noticed that bevy main already does this, when migrating to 0.15, we can just move the `cosmic_text` import to bevy